### PR TITLE
Fix ArtifactId.toMvnId to be symmetrical with fromMvnId

### DIFF
--- a/featuremodel/feature/src/main/java/org/apache/sling/feature/ArtifactId.java
+++ b/featuremodel/feature/src/main/java/org/apache/sling/feature/ArtifactId.java
@@ -205,8 +205,6 @@ public class ArtifactId implements Comparable<ArtifactId> {
         sb.append(this.groupId);
         sb.append(':');
         sb.append(this.artifactId);
-        sb.append(':');
-        sb.append(version);
         if ( this.classifier != null || !"jar".equals(this.type)) {
             sb.append(':');
             sb.append(this.type);
@@ -215,6 +213,8 @@ public class ArtifactId implements Comparable<ArtifactId> {
                 sb.append(this.classifier);
             }
         }
+        sb.append(':');
+        sb.append(version);
         return sb.toString();
     }
 

--- a/featuremodel/feature/src/test/java/org/apache/sling/feature/ArtifactIdTest.java
+++ b/featuremodel/feature/src/test/java/org/apache/sling/feature/ArtifactIdTest.java
@@ -141,4 +141,9 @@ public class ArtifactIdTest {
         assertEquals("zip", id.getType());
         assertEquals("foo", id.getClassifier());
     }
+
+    @Test public void testClassifierAndTypeToMvnId() {
+        final ArtifactId id = new ArtifactId("group.a", "artifact.b", "1.0", "foo", "zip");
+        assertEquals("group.a:artifact.b:zip:foo:1.0", id.toMvnId());
+    }
 }


### PR DESCRIPTION
The fromMvnId method expects the values in the `groupId:artifactId[:packaging[:classifier]]:version` format, but toMvnId was outputting them in the `groupId:artifactId:version[:packaging[:classifier]]` format.