### PR TITLE
SLING-7521 Order bundles in the generated app based on feature order and start order

### DIFF
--- a/featuremodel/example/sling/oak.json
+++ b/featuremodel/example/sling/oak.json
@@ -3,35 +3,35 @@
     "bundles": [
         {
             "id": "org.apache.felix/org.apache.felix.jaas/1.0.2",
-            "startOrder" : 10
+            "start-order" : 10
         },
         {
             "id": "org.apache.jackrabbit/oak-blob/1.6.4",
-            "startOrder" : 15
+            "start-order" : 15
         },
         {
             "id": "org.apache.jackrabbit/oak-commons/1.6.4",
-            "startOrder" : 15
+            "start-order" : 15
         },
         {
             "id": "org.apache.jackrabbit/oak-core/1.6.4",
-            "startOrder" : 15
+            "start-order" : 15
         },
         {
             "id": "org.apache.jackrabbit/oak-jcr/1.6.4", 
-            "startOrder" : 15
+            "start-order" : 15
         },
         {
             "id": "org.apache.jackrabbit/oak-lucene/1.6.4",
-            "startOrder" : 15
+            "start-order" : 15
         },
         {
             "id": "org.apache.jackrabbit/oak-segment-tar/1.6.4",
-            "startOrder" : 15
+            "start-order" : 15
         },
         {
             "id": "org.apache.sling/org.apache.sling.jcr.oak.server/1.1.4",
-            "startOrder" : 16
+            "start-order" : 16
         }
     ],
     "configurations": {

--- a/featuremodel/example/sling/sling.json
+++ b/featuremodel/example/sling/sling.json
@@ -3,415 +3,415 @@
     "bundles": [
         {
             "id": "commons-fileupload/commons-fileupload/1.3.2",
-            "startOrder" : 5
+            "start-order" : 5
         },
         {
             "id": "commons-io/commons-io/2.5",
-            "startOrder" : 5
+            "start-order" : 5
         },
         {
             "id": "org.apache.aries.jmx/org.apache.aries.jmx.api/1.1.5",
-            "startOrder" : 5
+            "start-order" : 5
         },
         {
             "id": "org.apache.aries.jmx/org.apache.aries.jmx.core/1.1.7",
-            "startOrder" : 5
+            "start-order" : 5
         },
         {
             "id": "org.apache.aries.jmx/org.apache.aries.jmx.whiteboard/1.1.5",
-            "startOrder" : 5
+            "start-order" : 5
         },
         {
             "id": "org.apache.felix/org.apache.felix.bundlerepository/1.6.4",
-            "startOrder" : 5
+            "start-order" : 5
         },
         {
             "id": "org.apache.felix/org.apache.felix.inventory/1.0.4",
-            "startOrder" : 5
+            "start-order" : 5
         },
         {
             "id": "org.apache.felix/org.apache.felix.prefs/1.1.0", 
-            "startOrder" : 5
+            "start-order" : 5
         },
         {
             "id": "org.apache.felix/org.apache.felix.webconsole.plugins.ds/2.0.6", 
-            "startOrder" : 5
+            "start-order" : 5
         },
         {
             "id": "org.apache.felix/org.apache.felix.webconsole.plugins.event/1.1.6", 
-            "startOrder" : 5
+            "start-order" : 5
         },
         {
             "id": "org.apache.felix/org.apache.felix.webconsole.plugins.memoryusage/1.0.6", 
-            "startOrder" : 5
+            "start-order" : 5
         },
         {
             "id": "org.apache.felix/org.apache.felix.webconsole.plugins.obr/1.0.4", 
-            "startOrder" : 5
+            "start-order" : 5
         },
         {
             "id": "org.apache.felix/org.apache.felix.webconsole.plugins.packageadmin/1.0.4", 
-            "startOrder" : 5
+            "start-order" : 5
         },
         {
             "id": "org.apache.felix/org.apache.felix.webconsole/4.3.4", 
-            "startOrder" : 5
+            "start-order" : 5
         },
         {
             "id": "org.apache.sling/org.apache.sling.commons.johnzon/1.1.0", 
-            "startOrder" : 5
+            "start-order" : 5
         },
         {
             "id": "org.apache.sling/org.apache.sling.commons.log.webconsole/1.0.0", 
-            "startOrder" : 5
+            "start-order" : 5
         },
         {
             "id": "org.apache.sling/org.apache.sling.extensions.threaddump/0.2.2", 
-            "startOrder" : 5
+            "start-order" : 5
         },
         {
             "id": "org.apache.sling/org.apache.sling.extensions.webconsolebranding/1.0.2", 
-            "startOrder" : 5
+            "start-order" : 5
         },
         {
             "id": "org.apache.sling/org.apache.sling.extensions.webconsolesecurityprovider/1.0.0", 
-            "startOrder" : 5
+            "start-order" : 5
         },
         {
             "id": "org.apache.felix/org.apache.felix.http.sslfilter/1.2.2", 
-            "startOrder" : 10
+            "start-order" : 10
         },
         {
             "id": "org.apache.felix/org.apache.felix.metatype/1.1.4", 
-            "startOrder" : 10
+            "start-order" : 10
         },
         {
             "id": "org.apache.felix/org.apache.felix.scr/2.0.12", 
-            "startOrder" : 10
+            "start-order" : 10
         },
         {
             "id": "org.apache.pdfbox/fontbox/2.0.7", 
-            "startOrder" : 10
+            "start-order" : 10
         },
         {
             "id": "org.apache.pdfbox/jempbox/1.8.13", 
-            "startOrder" : 10
+            "start-order" : 10
         },
         {
             "id": "org.apache.pdfbox/pdfbox/2.0.7", 
-            "startOrder" : 10
+            "start-order" : 10
         },
         {
             "id": "org.apache.tika/tika-core/1.14", 
-            "startOrder" : 10
+            "start-order" : 10
         },
         {
             "id": "org.apache.tika/tika-parsers/1.14", 
-            "startOrder" : 10
+            "start-order" : 10
         },
         {
             "id": "com.google.guava/guava/15.0",
-            "startOrder" : 15
+            "start-order" : 15
         },
         {
             "id": "io.dropwizard.metrics/metrics-core/3.2.3",
-            "startOrder" : 15
+            "start-order" : 15
         },
         {
             "id": "org.apache.jackrabbit/jackrabbit-api/2.14.3", 
-            "startOrder" : 15
+            "start-order" : 15
         },
         {
             "id": "org.apache.jackrabbit/jackrabbit-data/2.14.3", 
-            "startOrder" : 15
+            "start-order" : 15
         },
         {
             "id": "org.apache.jackrabbit/jackrabbit-jcr-commons/2.14.3", 
-            "startOrder" : 15
+            "start-order" : 15
         },
         {
             "id": "org.apache.jackrabbit/jackrabbit-jcr-rmi/2.14.3", 
-            "startOrder" : 15
+            "start-order" : 15
         },
         {
             "id": "org.apache.jackrabbit/jackrabbit-spi-commons/2.14.3", 
-            "startOrder" : 15
+            "start-order" : 15
         },
         {
             "id": "org.apache.jackrabbit/jackrabbit-spi/2.14.3", 
-            "startOrder" : 15
+            "start-order" : 15
         },
         {
             "id": "org.apache.jackrabbit/jackrabbit-webdav/2.14.3", 
-            "startOrder" : 15
+            "start-order" : 15
         },
         {
             "id": "org.apache.sling/org.apache.sling.commons.metrics/1.2.0", 
-            "startOrder" : 15
+            "start-order" : 15
         },
         {
             "id": "org.apache.sling/org.apache.sling.jcr.api/2.4.0", 
-            "startOrder" : 15
+            "start-order" : 15
         },
         {
             "id": "org.apache.sling/org.apache.sling.jcr.base/3.0.4", 
-            "startOrder" : 15
+            "start-order" : 15
         },
         {
             "id": "org.apache.sling/org.apache.sling.jcr.davex/1.3.8", 
-            "startOrder" : 15
+            "start-order" : 15
         },
         {
             "id": "org.apache.sling/org.apache.sling.jcr.jackrabbit.accessmanager/3.0.0", 
-            "startOrder" : 15
+            "start-order" : 15
         },
         {
             "id": "org.apache.sling/org.apache.sling.jcr.jackrabbit.usermanager/2.2.6", 
-            "startOrder" : 15
+            "start-order" : 15
         },
         {
             "id": "org.apache.sling/org.apache.sling.jcr.jcr-wrapper/2.0.0", 
-            "startOrder" : 15
+            "start-order" : 15
         },
         {
             "id": "org.apache.sling/org.apache.sling.jcr.registration/1.0.2", 
-            "startOrder" : 15
+            "start-order" : 15
         },
         {
             "id": "org.apache.sling/org.apache.sling.jcr.webconsole/1.0.2", 
-            "startOrder" : 15
+            "start-order" : 15
         },
         {
             "id": "org.apache.sling/org.apache.sling.jcr.webdav/2.3.8", 
-            "startOrder" : 15
+            "start-order" : 15
         },
         {
             "id": "commons-codec/commons-codec/1.9", 
-            "startOrder" : 20
+            "start-order" : 20
         },
         {
             "id": "commons-collections/commons-collections/3.2.2", 
-            "startOrder" : 20
+            "start-order" : 20
         },
         {
             "id": "commons-lang/commons-lang/2.6", 
-            "startOrder" : 20
+            "start-order" : 20
         },
         {
             "id": "javax.mail/mail/1.4.7", 
-            "startOrder" : 20
+            "start-order" : 20
         },
         {
             "id": "org.apache.commons/commons-collections4/4.1", 
-            "startOrder" : 20
+            "start-order" : 20
         },
         {
             "id": "org.apache.commons/commons-lang3/3.5", 
-            "startOrder" : 20
+            "start-order" : 20
         },
         {
             "id": "org.apache.commons/commons-math/2.2", 
-            "startOrder" : 20
+            "start-order" : 20
         },
         {
             "id": "org.apache.felix/org.apache.felix.http.whiteboard/3.0.0", 
-            "startOrder" : 20
+            "start-order" : 20
         },
         {
             "id": "org.apache.geronimo.bundles/commons-httpclient/3.1_1", 
-            "startOrder" : 20
+            "start-order" : 20
         },
         {
             "id": "org.apache.geronimo.bundles/jstl/1.2_1", 
-            "startOrder" : 20
+            "start-order" : 20
         },
         {
             "id": "org.apache.httpcomponents/httpclient-osgi/4.4.1", 
-            "startOrder" : 20
+            "start-order" : 20
         },
         {
             "id": "org.apache.httpcomponents/httpcore-osgi/4.4.1", 
-            "startOrder" : 20
+            "start-order" : 20
         },
         {
             "id": "org.apache.servicemix.bundles/org.apache.servicemix.bundles.rhino/1.7.7.1_1", 
-            "startOrder" : 20
+            "start-order" : 20
         },
         {
             "id": "org.apache.sling/org.apache.sling.adapter/2.1.10", 
-            "startOrder" : 20
+            "start-order" : 20
         },
         {
             "id": "org.apache.sling/org.apache.sling.api/2.16.2", 
-            "startOrder" : 20
+            "start-order" : 20
         },
         {
             "id": "org.apache.sling/org.apache.sling.auth.core/1.4.0", 
-            "startOrder" : 20
+            "start-order" : 20
         },
         {
             "id": "org.apache.sling/org.apache.sling.auth.form/1.0.8", 
-            "startOrder" : 20
+            "start-order" : 20
         },
         {
             "id": "org.apache.sling/org.apache.sling.bundleresource.impl/2.2.0", 
-            "startOrder" : 20
+            "start-order" : 20
         },
         {
             "id": "org.apache.sling/org.apache.sling.commons.classloader/1.4.0", 
-            "startOrder" : 20
+            "start-order" : 20
         },
         {
             "id": "org.apache.sling/org.apache.sling.commons.compiler/2.3.0", 
-            "startOrder" : 20
+            "start-order" : 20
         },
         {
             "id": "org.apache.sling/org.apache.sling.commons.fsclassloader/1.0.6", 
-            "startOrder" : 20
+            "start-order" : 20
         },
         {
             "id": "org.apache.sling/org.apache.sling.commons.mime/2.1.10", 
-            "startOrder" : 20
+            "start-order" : 20
         },
         {
             "id": "org.apache.sling/org.apache.sling.commons.osgi/2.4.0", 
-            "startOrder" : 20
+            "start-order" : 20
         },
         {
             "id": "org.apache.sling/org.apache.sling.commons.scheduler/2.6.2", 
-            "startOrder" : 20
+            "start-order" : 20
         },
         {
             "id": "org.apache.sling/org.apache.sling.commons.threads/3.2.6", 
-            "startOrder" : 20
+            "start-order" : 20
         },
         {
             "id": "org.apache.sling/org.apache.sling.engine/2.6.8", 
-            "startOrder" : 20
+            "start-order" : 20
         },
         {
             "id": "org.apache.sling/org.apache.sling.fsresource/2.1.8", 
-            "startOrder" : 20
+            "start-order" : 20
         },
         {
             "id": "org.apache.sling/org.apache.sling.hc.api/1.0.0", 
-            "startOrder" : 20
+            "start-order" : 20
         },
         {
             "id": "org.apache.sling/org.apache.sling.hc.core/1.2.8", 
-            "startOrder" : 20
+            "start-order" : 20
         },
         {
             "id": "org.apache.sling/org.apache.sling.hc.webconsole/1.1.2", 
-            "startOrder" : 20
+            "start-order" : 20
         },
         {
             "id": "org.apache.sling/org.apache.sling.i18n/2.5.8", 
-            "startOrder" : 20
+            "start-order" : 20
         },
         {
             "id": "org.apache.sling/org.apache.sling.installer.console/1.0.2", 
-            "startOrder" : 20
+            "start-order" : 20
         },
         {
             "id": "org.apache.sling/org.apache.sling.installer.provider.jcr/3.1.26", 
-            "startOrder" : 20
+            "start-order" : 20
         },
         {
             "id": "org.apache.sling/org.apache.sling.jcr.contentloader/2.2.4", 
-            "startOrder" : 20
+            "start-order" : 20
         },
         {
             "id": "org.apache.sling/org.apache.sling.jcr.resource/3.0.4", 
-            "startOrder" : 20
+            "start-order" : 20
         },
         {
             "id": "org.apache.sling/org.apache.sling.launchpad.content/2.0.12", 
-            "startOrder" : 20
+            "start-order" : 20
         },
         {
             "id": "org.apache.sling/org.apache.sling.models.api/1.3.4", 
-            "startOrder" : 20
+            "start-order" : 20
         },
         {
             "id": "org.apache.sling/org.apache.sling.models.impl/1.4.2", 
-            "startOrder" : 20
+            "start-order" : 20
         },
         {
             "id": "org.apache.sling/org.apache.sling.resourceresolver/1.5.30", 
-            "startOrder" : 20
+            "start-order" : 20
         },
         {
             "id": "org.apache.sling/org.apache.sling.scripting.api/2.2.0", 
-            "startOrder" : 20
+            "start-order" : 20
         },
         {
             "id": "org.apache.sling/org.apache.sling.scripting.core/2.0.46", 
-            "startOrder" : 20
+            "start-order" : 20
         },
         {
             "id": "org.apache.sling/org.apache.sling.scripting.el-api/1.0.0", 
-            "startOrder" : 20
+            "start-order" : 20
         },
         {
             "id": "org.apache.sling/org.apache.sling.scripting.javascript/3.0.2", 
-            "startOrder" : 20
+            "start-order" : 20
         },
         {
             "id": "org.apache.sling/org.apache.sling.scripting.jsp-api/1.0.0", 
-            "startOrder" : 20
+            "start-order" : 20
         },
         {
             "id": "org.apache.sling/org.apache.sling.scripting.jsp.taglib/2.2.6", 
-            "startOrder" : 20
+            "start-order" : 20
         },
         {
             "id": "org.apache.sling/org.apache.sling.scripting.jsp/2.3.2", 
-            "startOrder" : 20
+            "start-order" : 20
         },
         {
             "id": "org.apache.sling/org.apache.sling.scripting.sightly.compiler.java/1.0.12", 
-            "startOrder" : 20
+            "start-order" : 20
         },
         {
             "id": "org.apache.sling/org.apache.sling.scripting.sightly.compiler/1.0.12", 
-            "startOrder" : 20
+            "start-order" : 20
         },
         {
             "id": "org.apache.sling/org.apache.sling.scripting.sightly.js.provider/1.0.24", 
-            "startOrder" : 20
+            "start-order" : 20
         },
         {
             "id": "org.apache.sling/org.apache.sling.scripting.sightly.models.provider/1.0.6", 
-            "startOrder" : 20
+            "start-order" : 20
         },
         {
             "id": "org.apache.sling/org.apache.sling.scripting.sightly.repl/1.0.4", 
-            "startOrder" : 20
+            "start-order" : 20
         },
         {
             "id": "org.apache.sling/org.apache.sling.scripting.sightly/1.0.40", 
-            "startOrder" : 20
+            "start-order" : 20
         },
         {
             "id": "org.apache.sling/org.apache.sling.serviceusermapper/1.3.4", 
-            "startOrder" : 20
+            "start-order" : 20
         },
         {
             "id": "org.apache.sling/org.apache.sling.servlets.get/2.1.26", 
-            "startOrder" : 20
+            "start-order" : 20
         },
         {
             "id": "org.apache.sling/org.apache.sling.servlets.post/2.3.22", 
-            "startOrder" : 20
+            "start-order" : 20
         },
         {
             "id": "org.apache.sling/org.apache.sling.servlets.resolver/2.4.14", 
-            "startOrder" : 20
+            "start-order" : 20
         },
         {
             "id": "org.apache.sling/org.apache.sling.xss/2.0.0", 
-            "startOrder" : 20
+            "start-order" : 20
         }
     ],
     "configurations": {

--- a/featuremodel/feature-analyser/src/test/resources/feature_complete.json
+++ b/featuremodel/feature-analyser/src/test/resources/feature_complete.json
@@ -4,79 +4,79 @@
     "bundles" : [
         {
           "id" : "org.apache.sling/org.apache.sling.commons.log/5.0.0",
-          "startOrder" : 1
+          "start-order" : 1
         },
         {
           "id" : "org.apache.sling/org.apache.sling.commons.logservice/1.0.6",
-          "startOrder" : 1
+          "start-order" : 1
         },
         {
           "id" : "org.slf4j/jcl-over-slf4j/1.7.21",
-          "startOrder" : 1
+          "start-order" : 1
         },
         {
           "id" : "org.slf4j/log4j-over-slf4j/1.7.21",
-          "startOrder" : 1
+          "start-order" : 1
         },
         {
           "id" : "org.slf4j/slf4j-api/1.7.21",
-          "startOrder" : 1
+          "start-order" : 1
         },
         {
           "id" : "org.apache.felix/org.apache.felix.configadmin/1.8.14",
-          "startOrder" : 1
+          "start-order" : 1
         },
         {
           "id" : "org.apache.felix/org.apache.felix.eventadmin/1.4.8",
-          "startOrder" : 4
+          "start-order" : 4
         },
         {
           "id" : "org.apache.felix/org.apache.felix.metatype/1.1.2",
-          "startOrder" : 4
+          "start-order" : 4
         },
         {
           "id" : "org.apache.felix/org.apache.felix.scr/2.0.12",
-          "startOrder" : 4
+          "start-order" : 4
         },
         {
           "id" : "org.apache.felix/org.apache.felix.http.jetty/3.4.2",
-          "startOrder" : 5
+          "start-order" : 5
         },
         {
           "id" : "org.apache.felix/org.apache.felix.http.servlet-api/1.1.2",
-          "startOrder" : 5
+          "start-order" : 5
         },
         {
           "id" : "commons-io/commons-io/2.5",
-          "startOrder" : 5
+          "start-order" : 5
         },
         {
           "id" : "commons-fileupload/commons-fileupload/1.3.2",
-          "startOrder" : 5
+          "start-order" : 5
         },
         {
           "id" : "org.apache.felix/org.apache.felix.inventory/1.0.4",
-          "startOrder" : 5
+          "start-order" : 5
         },
         {
           "id" : "org.apache.felix/org.apache.felix.webconsole.plugins.ds/2.0.6",
-          "startOrder" : 5
+          "start-order" : 5
         },
         {
           "id" : "org.apache.felix/org.apache.felix.webconsole.plugins.event/1.1.6",
-          "startOrder" : 5
+          "start-order" : 5
         },
         {
           "id" : "org.apache.felix/org.apache.felix.webconsole.plugins.packageadmin/1.0.4",
-          "startOrder" : 5
+          "start-order" : 5
         },
         {
           "id" : "org.apache.felix/org.apache.felix.webconsole/4.3.4",
-          "startOrder" : 5
+          "start-order" : 5
         },
         {
           "id" : "org.apache.sling/org.apache.sling.commons.log.webconsole/1.0.0",
-          "startOrder" : 5
+          "start-order" : 5
         }
     ]
 }

--- a/featuremodel/feature-analyser/src/test/resources/feature_incomplete.json
+++ b/featuremodel/feature-analyser/src/test/resources/feature_incomplete.json
@@ -4,79 +4,79 @@
     "bundles" : [
         {
           "id" : "org.apache.sling/org.apache.sling.commons.log/5.0.0",
-          "startOrder" : 1
+          "start-order" : 1
         },
         {
           "id" : "org.apache.sling/org.apache.sling.commons.logservice/1.0.6",
-          "startOrder" : 1
+          "start-order" : 1
         },
         {
           "id" : "org.slf4j/jcl-over-slf4j/1.7.21",
-          "startOrder" : 1
+          "start-order" : 1
         },
         {
           "id" : "org.slf4j/log4j-over-slf4j/1.7.21",
-          "startOrder" : 1
+          "start-order" : 1
         },
         {
           "id" : "org.slf4j/slf4j-api/1.7.21",
-          "startOrder" : 1
+          "start-order" : 1
         },
         {
           "id" : "org.apache.felix/org.apache.felix.configadmin/1.8.14",
-          "startOrder" : 1
+          "start-order" : 1
         },
         {
           "id" : "org.apache.felix/org.apache.felix.eventadmin/1.4.8",
-          "startOrder" : 4
+          "start-order" : 4
         },
         {
           "id" : "org.apache.felix/org.apache.felix.metatype/1.1.2",
-          "startOrder" : 4
+          "start-order" : 4
         },
         {
           "id" : "org.apache.felix/org.apache.felix.scr/2.0.12",
-          "startOrder" : 4
+          "start-order" : 4
         },
         {
           "id" : "org.apache.felix/org.apache.felix.http.servlet-api/1.1.2",
-          "startOrder" : 5
+          "start-order" : 5
         },
         {
           "id" : "commons-io/commons-io/2.5",
-          "startOrder" : 5
+          "start-order" : 5
         },
         {
           "id" : "commons-fileupload/commons-fileupload/1.3.2",
-          "startOrder" : 5
+          "start-order" : 5
         },
         {
           "id" : "org.apache.felix/org.apache.felix.inventory/1.0.4",
-          "startOrder" : 5
+          "start-order" : 5
         },
         {
           "id" : "org.apache.felix/org.apache.felix.webconsole.plugins.ds/2.0.6",
-          "startOrder" : 5
+          "start-order" : 5
         },
         {
           "id" : "org.apache.felix/org.apache.felix.webconsole.plugins.event/1.1.6",
-          "startOrder" : 5
+          "start-order" : 5
         },
         {
           "id" : "org.apache.felix/org.apache.felix.webconsole.plugins.packageadmin/1.0.4",
-          "startOrder" : 5
+          "start-order" : 5
         },
         {
           "id" : "org.apache.felix/org.apache.felix.webconsole/4.3.4",
-          "startOrder" : 5
+          "start-order" : 5
         },
         {
           "id" : "org.apache.sling/org.apache.sling.commons.log.webconsole/1.0.0",
-          "startOrder" : 5
+          "start-order" : 5
         },
         {
           "id" : "org.apache.sling/org.apache.sling.i18n/2.5.8",
-          "startOrder" : 6
+          "start-order" : 6
         }
     ]
 }

--- a/featuremodel/feature-applicationbuilder/pom.xml
+++ b/featuremodel/feature-applicationbuilder/pom.xml
@@ -132,11 +132,36 @@
             <version>0.0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
-                
-      <!-- Testing -->
         <dependency>
-        	<groupId>junit</groupId>
-        	<artifactId>junit</artifactId>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.commons.osgi</artifactId>
+            <version>2.4.0</version>
+            <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.service.resolver</artifactId>
+            <version>1.0.1</version>
+            <scope>provided</scope>
+        </dependency>
+                
+        <!-- Testing -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.framework</artifactId>
+            <version>5.6.10</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.feature.analyser</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>        
     </dependencies>
 </project>

--- a/featuremodel/feature-applicationbuilder/src/test/java/org/apache/sling/feature/applicationbuilder/impl/ApplicationBuilderTest.java
+++ b/featuremodel/feature-applicationbuilder/src/test/java/org/apache/sling/feature/applicationbuilder/impl/ApplicationBuilderTest.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.sling.feature.applicationbuilder.impl;
+
+import org.apache.sling.feature.Application;
+import org.apache.sling.feature.ArtifactId;
+import org.apache.sling.feature.Feature;
+import org.apache.sling.feature.process.ApplicationBuilder;
+import org.apache.sling.feature.process.BuilderContext;
+import org.apache.sling.feature.process.FeatureProvider;
+import org.apache.sling.feature.process.FeatureResolver;
+import org.apache.sling.feature.resolver.FrameworkResolver;
+import org.apache.sling.feature.support.ArtifactHandler;
+import org.apache.sling.feature.support.ArtifactManager;
+import org.apache.sling.feature.support.ArtifactManagerConfig;
+import org.apache.sling.feature.support.json.ApplicationJSONWriter;
+import org.apache.sling.feature.support.json.FeatureJSONReader;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.osgi.framework.Constants;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class ApplicationBuilderTest {
+    private Path tempDir;
+
+    @Before
+    public void setup() throws Exception {
+        tempDir = Files.createTempDirectory(getClass().getSimpleName());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        // Delete the temp dir again
+        Files.walk(tempDir)
+            .sorted(Comparator.reverseOrder())
+            .map(Path::toFile)
+            .forEach(File::delete);
+    }
+
+    private Map<String, String> getFrameworkProps() {
+        return Collections.singletonMap(Constants.FRAMEWORK_STORAGE, tempDir.toFile().getAbsolutePath());
+    }
+
+    @Test
+    public void testBundleOrdering() throws Exception {
+        FeatureProvider fp = new TestFeatureProvider();
+        BuilderContext bc = new BuilderContext(fp);
+        ArtifactManager am = ArtifactManager.getArtifactManager(new ArtifactManagerConfig());
+
+        Feature fa = readFeature("/featureA.json", am);
+        Feature fb = readFeature("/featureB.json", am);
+        Feature[] features = {fa, fb};
+
+        try (FeatureResolver fr = new FrameworkResolver(am, getFrameworkProps())) {
+            Application app = ApplicationBuilder.assemble(null, bc, fr, features);
+            String genApp = writeApplication(app);
+
+            String expected = "{\"features\":["
+                    + "\"org.apache.sling.test.features:featureB:1.0.0\","
+                    + "\"org.apache.sling.test.features:featureA:1.0.0\"],"
+                + "\"bundles\":["
+                    + "{\"id\":\"commons-io:commons-io:2.6\",\"start-order\":\"10\"},"
+                    + "{\"id\":\"org.apache.felix:org.apache.felix.http.servlet-api:1.1.2\",\"start-order\":\"15\"},"
+                    + "{\"id\":\"commons-fileupload:commons-fileupload:1.3.3\",\"start-order\":\"16\"}]}";
+            assertEquals(expected, genApp);
+        }
+    }
+
+    @Test
+    public void testFeatureDependency() throws Exception {
+        FeatureProvider fp = new TestFeatureProvider();
+        BuilderContext bc = new BuilderContext(fp);
+        ArtifactManager am = ArtifactManager.getArtifactManager(new ArtifactManagerConfig());
+
+        // Feature D has a bundle (slf4j-api) with a dependency on feature C,
+        // which provides a package for slf4j
+        Feature fc = readFeature("/featureC.json", am);
+        Feature fd = readFeature("/featureD.json", am);
+        Feature[] features = {fd, fc};
+
+        try (FeatureResolver fr = new FrameworkResolver(am, getFrameworkProps())) {
+            Application app = ApplicationBuilder.assemble(null, bc, fr, features);
+            String genApp = writeApplication(app);
+
+            String expected = "{\"features\":["
+                    + "\"org.apache.sling.test.features:featureC:1.0.0\","
+                    + "\"org.apache.sling.test.features:featureD:1.0.0\"],"
+                    + "\"bundles\":[{\"id\":\"org.slf4j:slf4j-api:1.7.25\",\"start-order\":\"6\"}]}";
+            assertEquals(expected, genApp);
+        }
+    }
+
+    private static String writeApplication(Application app) throws Exception {
+        Writer writer = new StringWriter();
+        ApplicationJSONWriter.write(writer, app);
+        return writer.toString();
+    }
+
+    private Feature readFeature(final String res,
+            final ArtifactManager artifactManager) throws Exception {
+        URL url = getClass().getResource(res);
+        String file = new File(url.toURI()).getAbsolutePath();
+        final ArtifactHandler featureArtifact = artifactManager.getArtifactHandler(file);
+
+        try (final FileReader r = new FileReader(featureArtifact.getFile())) {
+            final Feature f = FeatureJSONReader.read(r, featureArtifact.getUrl());
+            return f;
+        }
+    }
+
+    private static class TestFeatureProvider implements FeatureProvider {
+        @Override
+        public Feature provide(ArtifactId id) {
+            return null;
+        }
+    }
+}

--- a/featuremodel/feature-applicationbuilder/src/test/resources/featureA.json
+++ b/featuremodel/feature-applicationbuilder/src/test/resources/featureA.json
@@ -1,0 +1,5 @@
+{
+    "id": "org.apache.sling.test.features/featureA/1.0.0",
+    "bundles": 
+        ["commons-fileupload/commons-fileupload/1.3.3"]
+}

--- a/featuremodel/feature-applicationbuilder/src/test/resources/featureB.json
+++ b/featuremodel/feature-applicationbuilder/src/test/resources/featureB.json
@@ -1,8 +1,7 @@
 {
-    "id": "org.apache.sling.test.features/feature3/1.0.0",
+    "id": "org.apache.sling.test.features/featureB/1.0.0",
     "bundles": 
         [
-            "org.slf4j/slf4j-simple/1.7.25",
             {
                 "id": "org.apache.felix/org.apache.felix.http.servlet-api/1.1.2",
                 "start-order" : 10

--- a/featuremodel/feature-applicationbuilder/src/test/resources/featureC.json
+++ b/featuremodel/feature-applicationbuilder/src/test/resources/featureC.json
@@ -1,0 +1,18 @@
+{
+    "id": "org.apache.sling.test.features/featureC/1.0.0",
+    "capabilities": [
+        {
+            "namespace": "org.foo.bar",
+            "attributes": {
+                "org.foo.bar": "toast",
+                "version:Version": "1.1"
+            }
+        }, {
+            "namespace": "osgi.wiring.package",
+            "attributes": {
+                "osgi.wiring.package": "org.slf4j.impl",
+                "version:Version": "1.7.1.test"
+            }
+        }
+    ]
+}

--- a/featuremodel/feature-applicationbuilder/src/test/resources/featureD.json
+++ b/featuremodel/feature-applicationbuilder/src/test/resources/featureD.json
@@ -1,0 +1,5 @@
+{
+    "id": "org.apache.sling.test.features/featureD/1.0.0",
+    "bundles": 
+        ["org.slf4j/slf4j-api/1.7.25"]
+}

--- a/featuremodel/feature-resolver/pom.xml
+++ b/featuremodel/feature-resolver/pom.xml
@@ -73,6 +73,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.commons.osgi</artifactId>
+            <version>2.4.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.resolver</artifactId>
             <version>1.0.1</version>
@@ -94,6 +100,18 @@
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.framework</artifactId>
             <version>5.6.10</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.configurator</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.commons.johnzon</artifactId>
+            <version>1.0.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/featuremodel/feature-resolver/src/main/java/org/apache/sling/feature/resolver/FrameworkResolver.java
+++ b/featuremodel/feature-resolver/src/main/java/org/apache/sling/feature/resolver/FrameworkResolver.java
@@ -16,25 +16,15 @@
  */
 package org.apache.sling.feature.resolver;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.ServiceLoader;
-import java.util.Set;
-
 import org.apache.sling.feature.Artifact;
 import org.apache.sling.feature.ArtifactId;
 import org.apache.sling.feature.Feature;
+import org.apache.sling.feature.FeatureResource;
 import org.apache.sling.feature.analyser.BundleDescriptor;
 import org.apache.sling.feature.analyser.impl.BundleDescriptorImpl;
 import org.apache.sling.feature.process.FeatureResolver;
 import org.apache.sling.feature.resolver.impl.BundleResourceImpl;
+import org.apache.sling.feature.resolver.impl.FeatureResourceImpl;
 import org.apache.sling.feature.resolver.impl.ResolveContextImpl;
 import org.apache.sling.feature.support.ArtifactManager;
 import org.osgi.framework.BundleContext;
@@ -44,6 +34,7 @@ import org.osgi.framework.launch.Framework;
 import org.osgi.framework.launch.FrameworkFactory;
 import org.osgi.framework.namespace.BundleNamespace;
 import org.osgi.framework.namespace.HostNamespace;
+import org.osgi.framework.namespace.IdentityNamespace;
 import org.osgi.framework.namespace.PackageNamespace;
 import org.osgi.framework.wiring.BundleRevision;
 import org.osgi.resource.Capability;
@@ -53,10 +44,19 @@ import org.osgi.resource.Wire;
 import org.osgi.service.resolver.ResolutionException;
 import org.osgi.service.resolver.Resolver;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceLoader;
+
 public class FrameworkResolver implements FeatureResolver {
     private final ArtifactManager artifactManager;
     private final Resolver resolver;
-    private final Resource frameworkResource;
+    private final FeatureResource frameworkResource;
     private final Framework framework;
 
     public FrameworkResolver(ArtifactManager am, Map<String, String> frameworkProperties) {
@@ -72,10 +72,13 @@ public class FrameworkResolver implements FeatureResolver {
             BundleContext ctx = framework.getBundleContext();
 
             // Create a resource representing the framework
+            Map<String, List<Capability>> capabilities = new HashMap<>();
             BundleRevision br = framework.adapt(BundleRevision.class);
-            List<Capability> caps = br.getCapabilities(PackageNamespace.PACKAGE_NAMESPACE);
-            frameworkResource = new BundleResourceImpl(
-                    Collections.singletonMap(PackageNamespace.PACKAGE_NAMESPACE, caps), Collections.emptyMap());
+            capabilities.put(PackageNamespace.PACKAGE_NAMESPACE, br.getCapabilities(PackageNamespace.PACKAGE_NAMESPACE));
+            capabilities.put(BundleNamespace.BUNDLE_NAMESPACE, br.getCapabilities(BundleNamespace.BUNDLE_NAMESPACE));
+            capabilities.put(IdentityNamespace.IDENTITY_NAMESPACE, br.getCapabilities(IdentityNamespace.IDENTITY_NAMESPACE));
+            frameworkResource = new BundleResourceImpl(framework.getSymbolicName(), framework.getVersion(), null, null,
+                    capabilities, Collections.emptyMap());
 
             int i=0;
             while (i < 20) {
@@ -101,65 +104,89 @@ public class FrameworkResolver implements FeatureResolver {
     }
 
     @Override
-    public List<Feature> orderFeatures(List<Feature> features) {
+    public List<FeatureResource> orderResources(List<Feature> features) {
         try {
-            return internalOrderFeatures(features);
+            return internalOrderResources(features);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
 
-    public List<Feature> internalOrderFeatures(List<Feature> features) throws IOException {
-        Map<Resource, Feature> bundleMap = new HashMap<>();
+    public List<FeatureResource> internalOrderResources(List<Feature> features) throws IOException {
+        Map<Feature, FeatureResource> featureMap = new HashMap<>();
+        Map<FeatureResource, Feature> resourceMap = new HashMap<>();
         for (Feature f : features) {
+            FeatureResourceImpl fr = new FeatureResourceImpl(f);
+            resourceMap.put(fr, f);
+            featureMap.put(f, fr);
+
             for (Artifact b : f.getBundles()) {
                 BundleDescriptor bd = getBundleDescriptor(artifactManager, b);
-                Resource r = new BundleResourceImpl(bd);
-                bundleMap.put(r, f);
+                FeatureResource r = new BundleResourceImpl(bd, f);
+                resourceMap.put(r, f);
             }
         }
 
-        Set<Resource> availableBundles = new HashSet<>(bundleMap.keySet());
-        // Add these to the available features
-        Artifact lpa = new Artifact(ArtifactId.parse("org.apache.sling/org.apache.sling.launchpad.api/1.2.0"));
-        availableBundles.add(new BundleResourceImpl(getBundleDescriptor(artifactManager, lpa)));
-        availableBundles.add(frameworkResource);
+        Map<String, FeatureResource> idVerMap = new HashMap<>();
+        for (FeatureResource fr : resourceMap.keySet()) {
+            idVerMap.put(fr.getId() + ":" + fr.getVersion(), fr);
+        }
 
-        List<Resource> orderedBundles = new LinkedList<>();
+        // Add these too
+        Artifact lpa = new Artifact(ArtifactId.parse("org.apache.sling/org.apache.sling.launchpad.api/1.2.0"));
+        idVerMap.put("org.apache.sling.launchpad.api:1.2.0", new BundleResourceImpl(getBundleDescriptor(artifactManager, lpa), null));
+        idVerMap.put(framework.getSymbolicName() + ":" + framework.getVersion(), frameworkResource);
+
+        List<FeatureResource> orderedResources = new LinkedList<>();
         try {
-            for (Resource bundle : bundleMap.keySet()) {
-                if (orderedBundles.contains(bundle)) {
+            for (FeatureResource resource : resourceMap.keySet()) {
+                if (orderedResources.contains(resource)) {
                     // Already handled
                     continue;
                 }
-                Map<Resource, List<Wire>> deps = resolver.resolve(new ResolveContextImpl(bundle, availableBundles));
+                Map<Resource, List<Wire>> deps = resolver.resolve(new ResolveContextImpl(resource, idVerMap.values()));
 
                 for (Map.Entry<Resource, List<Wire>> entry : deps.entrySet()) {
-                    Resource curBundle = entry.getKey();
-
-                    if (!bundleMap.containsKey(curBundle)) {
-                        // This is some synthesized bundle. Ignoring.
+                    if (resource.equals(entry.getKey()))
                         continue;
-                    }
 
-                    if (!orderedBundles.contains(curBundle)) {
-                        orderedBundles.add(curBundle);
+                    Resource depResource = entry.getKey();
+                    FeatureResource curResource = getFeatureResource(depResource, idVerMap);
+                    if (curResource == null)
+                        continue;
+
+                    if (!orderedResources.contains(curResource)) {
+                        orderedResources.add(curResource);
                     }
 
                     for (Wire w : entry.getValue()) {
-                        Resource provBundle = w.getProvider();
-                        int curBundleIdx = orderedBundles.indexOf(curBundle);
-                        int newBundleIdx = orderedBundles.indexOf(provBundle);
+                        FeatureResource provBundle = getFeatureResource(w.getProvider(), idVerMap);
+                        if (provBundle == null)
+                            continue;
+
+                        int curBundleIdx = orderedResources.indexOf(curResource);
+                        int newBundleIdx = orderedResources.indexOf(provBundle);
                         if (newBundleIdx >= 0) {
                             if (curBundleIdx < newBundleIdx) {
                                 // If the list already contains the providing but after the current bundle, remove it there to move it before the current bundle
-                                orderedBundles.remove(provBundle);
+                                orderedResources.remove(provBundle);
                             } else {
                                 // If the providing bundle is already before the current bundle, then no need to change anything
                                 continue;
                             }
                         }
-                        orderedBundles.add(curBundleIdx, provBundle);
+                        orderedResources.add(curBundleIdx, provBundle);
+                    }
+                }
+
+                // All of the dependencies of the resource have been added, now add the resource itself
+                if (!orderedResources.contains(resource)) {
+                    Feature associatedFeature = resource.getFeature();
+                    if (resource.equals(featureMap.get(associatedFeature))) {
+                        // The resource is a feature resource, don't add this one by itself.
+                    }
+                    else {
+                        orderedResources.add(resource);
                     }
                 }
             }
@@ -168,35 +195,62 @@ public class FrameworkResolver implements FeatureResolver {
         }
 
         // Sort the fragments so that fragments are started before the host bundle
-        for (int i=0; i<orderedBundles.size(); i++) {
-            Resource r = orderedBundles.get(i);
+        for (int i=0; i<orderedResources.size(); i++) {
+            Resource r = orderedResources.get(i);
             List<Requirement> reqs = r.getRequirements(HostNamespace.HOST_NAMESPACE);
             if (reqs.size() > 0) {
                 // This is a fragment
                 Requirement req = reqs.iterator().next(); // TODO handle more host requirements
                 String bsn = req.getAttributes().get(HostNamespace.HOST_NAMESPACE).toString(); // TODO this is not valid, should obtain from filter
-                int idx = getBundleIndex(orderedBundles, bsn); // TODO check for filter too
+                int idx = getBundleIndex(orderedResources, bsn); // TODO check for filter too
                 if (idx < i) {
                     // the fragment is after the host, and should be moved to be before the host
-                    Resource frag = orderedBundles.remove(i);
-                    orderedBundles.add(idx, frag);
+                    FeatureResource frag = orderedResources.remove(i);
+                    orderedResources.add(idx, frag);
                 }
             }
         }
 
-        List<Feature> orderedFeatures = new ArrayList<>();
-        for (Resource r : orderedBundles) {
-            Feature f = bundleMap.get(r);
-            if (f != null) {
-                if (!orderedFeatures.contains(f)) {
-                    orderedFeatures.add(f);
-                }
+        // Add the features at the appropriate place to the ordered resources list
+        for (int i=0; i<orderedResources.size(); i++) {
+            FeatureResource r = orderedResources.get(i);
+            FeatureResource associatedFeature = featureMap.get(r.getFeature());
+            if (associatedFeature == null)
+                continue;
+
+            int idx = orderedResources.indexOf(associatedFeature);
+            if (idx > i) {
+                orderedResources.remove(idx);
+                orderedResources.add(i, associatedFeature);
+            } else if (idx == -1) {
+                orderedResources.add(i, associatedFeature);
             }
         }
-        return orderedFeatures;
+
+        // If the framework shows up as a dependency, remove it as it's always there
+        orderedResources.remove(frameworkResource);
+
+        return orderedResources;
     }
 
-    private static int getBundleIndex(List<Resource> bundles, String bundleSymbolicName) {
+    private FeatureResource getFeatureResource(Resource res, Map<String, FeatureResource> idVerMap) {
+        if (res instanceof FeatureResource)
+            return (FeatureResource) res;
+
+        // Obtain the identity from the resource and look up in the resource
+        List<Capability> caps = res.getCapabilities(IdentityNamespace.IDENTITY_NAMESPACE);
+        if (caps.size() == 0) {
+            return null;
+        }
+        Capability cap = caps.get(0);
+        Map<String, Object> attrs = cap.getAttributes();
+        Object id = attrs.get(IdentityNamespace.IDENTITY_NAMESPACE);
+        Object ver = attrs.get(IdentityNamespace.CAPABILITY_VERSION_ATTRIBUTE);
+        String idVer = "" + id + ":" + ver;
+        return idVerMap.get(idVer);
+    }
+
+    private static int getBundleIndex(List<FeatureResource> bundles, String bundleSymbolicName) {
         for (int i=0; i<bundles.size(); i++) {
             Resource b = bundles.get(i);
             if (bundleSymbolicName.equals(getBundleSymbolicName(b))) {

--- a/featuremodel/feature-resolver/src/main/java/org/apache/sling/feature/resolver/impl/AbstractResourceImpl.java
+++ b/featuremodel/feature-resolver/src/main/java/org/apache/sling/feature/resolver/impl/AbstractResourceImpl.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.sling.feature.resolver.impl;
+
+import org.osgi.resource.Capability;
+import org.osgi.resource.Requirement;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+abstract class AbstractResourceImpl {
+    public List<Requirement> getRequirements(String namespace, Map<String, List<Requirement>> requirements) {
+        if (namespace == null) {
+            return requirements.values().stream().flatMap(Collection::stream).collect(Collectors.toList());
+        }
+
+        List<Requirement> reqs = requirements.get(namespace);
+        if (reqs == null)
+            return Collections.emptyList();
+        return reqs;
+    }
+
+    public List<Capability> getCapabilities(String namespace, Map<String, List<Capability>> capabilities) {
+        if (namespace == null) {
+            return capabilities.values().stream().flatMap(Collection::stream).collect(Collectors.toList());
+        }
+
+        List<Capability> caps = capabilities.get(namespace);
+        if (caps == null)
+            return Collections.emptyList();
+        return caps;
+    }
+}

--- a/featuremodel/feature-resolver/src/main/java/org/apache/sling/feature/resolver/impl/FeatureResourceImpl.java
+++ b/featuremodel/feature-resolver/src/main/java/org/apache/sling/feature/resolver/impl/FeatureResourceImpl.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.sling.feature.resolver.impl;
+
+import org.apache.sling.feature.Artifact;
+import org.apache.sling.feature.Feature;
+import org.apache.sling.feature.FeatureResource;
+import org.apache.sling.feature.OSGiCapability;
+import org.apache.sling.feature.OSGiRequirement;
+import org.osgi.framework.Version;
+import org.osgi.framework.namespace.IdentityNamespace;
+import org.osgi.resource.Capability;
+import org.osgi.resource.Requirement;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class FeatureResourceImpl extends AbstractResourceImpl implements FeatureResource {
+    private final Artifact artifact;
+    private final Feature feature;
+    private final Map<String, List<Capability>> capabilities;
+    private final Map<String, List<Requirement>> requirements;
+
+    public FeatureResourceImpl(Feature f) {
+        artifact = new Artifact(f.getId());
+        feature = f;
+
+        capabilities = new HashMap<>();
+        for (Capability r : f.getCapabilities()) {
+            List<Capability> l = capabilities.get(r.getNamespace());
+            if (l == null) {
+                l = new ArrayList<>();
+                capabilities.put(r.getNamespace(), l);
+            }
+            l.add(new OSGiCapability(this, r));
+        }
+
+        // Add the identity capability
+        Map<String, Object> idattrs = new HashMap<>();
+        idattrs.put(IdentityNamespace.IDENTITY_NAMESPACE, getId());
+        idattrs.put(IdentityNamespace.CAPABILITY_TYPE_ATTRIBUTE, "sling.feature");
+        idattrs.put(IdentityNamespace.CAPABILITY_VERSION_ATTRIBUTE, getVersion());
+        idattrs.put(IdentityNamespace.CAPABILITY_DESCRIPTION_ATTRIBUTE, f.getDescription());
+        idattrs.put(IdentityNamespace.CAPABILITY_LICENSE_ATTRIBUTE, f.getLicense());
+        OSGiCapability idCap = new OSGiCapability(this, IdentityNamespace.IDENTITY_NAMESPACE, idattrs, Collections.emptyMap());
+        capabilities.put(IdentityNamespace.IDENTITY_NAMESPACE, Collections.singletonList(idCap));
+
+        requirements = new HashMap<>();
+        for (Requirement r : f.getRequirements()) {
+            List<Requirement> l = requirements.get(r.getNamespace());
+            if (l == null) {
+                l = new ArrayList<>();
+                requirements.put(r.getNamespace(), l);
+            }
+            l.add(new OSGiRequirement(this, r));
+        }
+    }
+
+    @Override
+    public String getId() {
+        return artifact.getId().getArtifactId();
+    }
+
+    @Override
+    public Version getVersion() {
+        return artifact.getId().getOSGiVersion();
+    }
+
+    @Override
+    public Artifact getArtifact() {
+        return artifact;
+    }
+
+    @Override
+    public Feature getFeature() {
+        return feature;
+    }
+
+    @Override
+    public List<Capability> getCapabilities(String namespace) {
+        return super.getCapabilities(namespace, capabilities);
+    }
+
+    @Override
+    public List<Requirement> getRequirements(String namespace) {
+        return super.getRequirements(namespace, requirements);
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((artifact == null) ? 0 : artifact.hashCode());
+        result = prime * result + ((capabilities == null) ? 0 : capabilities.hashCode());
+        result = prime * result + ((feature == null) ? 0 : feature.hashCode());
+        result = prime * result + ((requirements == null) ? 0 : requirements.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        FeatureResourceImpl other = (FeatureResourceImpl) obj;
+        if (artifact == null) {
+            if (other.artifact != null)
+                return false;
+        } else if (!artifact.equals(other.artifact))
+            return false;
+        if (capabilities == null) {
+            if (other.capabilities != null)
+                return false;
+        } else if (!capabilities.equals(other.capabilities))
+            return false;
+        if (feature == null) {
+            if (other.feature != null)
+                return false;
+        } else if (!feature.equals(other.feature))
+            return false;
+        if (requirements == null) {
+            if (other.requirements != null)
+                return false;
+        } else if (!requirements.equals(other.requirements))
+            return false;
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "FeatureResourceImpl [artifact=" + artifact + "]";
+    }
+}

--- a/featuremodel/feature-resolver/src/main/java/org/apache/sling/feature/resolver/impl/ResolveContextImpl.java
+++ b/featuremodel/feature-resolver/src/main/java/org/apache/sling/feature/resolver/impl/ResolveContextImpl.java
@@ -16,12 +16,6 @@
  */
 package org.apache.sling.feature.resolver.impl;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-
 import org.osgi.framework.Filter;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.InvalidSyntaxException;
@@ -32,19 +26,25 @@ import org.osgi.resource.Wiring;
 import org.osgi.service.resolver.HostedCapability;
 import org.osgi.service.resolver.ResolveContext;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
 /**
  * Implementation of the OSGi ResolveContext for use with the OSGi Resolver.
  */
 public class ResolveContextImpl extends ResolveContext {
     private final Resource bundle;
-    private final Collection<Resource> availableResources;
+    private final Collection<? extends Resource> availableResources;
 
     /**
      * Constructor.
      * @param mainResource The main resource to resolve.
      * @param available The available resources to provide dependencies.
      */
-    public ResolveContextImpl(Resource mainResource, Collection<Resource> available) {
+    public ResolveContextImpl(Resource mainResource, Collection<? extends Resource> available) {
         bundle = mainResource;
         availableResources = available;
     }

--- a/featuremodel/feature-resolver/src/test/java/org/apache/sling/feature/resolver/FrameworkResolverTest.java
+++ b/featuremodel/feature-resolver/src/test/java/org/apache/sling/feature/resolver/FrameworkResolverTest.java
@@ -16,21 +16,8 @@
  */
 package org.apache.sling.feature.resolver;
 
-import static org.junit.Assert.assertEquals;
-
-import java.io.File;
-import java.io.FileReader;
-import java.net.URL;
-import java.nio.file.FileVisitOption;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
-
 import org.apache.sling.feature.Feature;
+import org.apache.sling.feature.FeatureResource;
 import org.apache.sling.feature.process.FeatureResolver;
 import org.apache.sling.feature.support.ArtifactHandler;
 import org.apache.sling.feature.support.ArtifactManager;
@@ -40,6 +27,19 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.osgi.framework.Constants;
+import org.osgi.framework.namespace.IdentityNamespace;
+
+import java.io.File;
+import java.io.FileReader;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
 
 public class FrameworkResolverTest {
     private Path tempDir;
@@ -52,7 +52,7 @@ public class FrameworkResolverTest {
     @After
     public void tearDown() throws Exception {
         // Delete the temp dir again
-        Files.walk(tempDir, FileVisitOption.FOLLOW_LINKS)
+        Files.walk(tempDir)
             .sorted(Comparator.reverseOrder())
             .map(Path::toFile)
             .forEach(File::delete);
@@ -67,23 +67,70 @@ public class FrameworkResolverTest {
         ArtifactManager am = ArtifactManager.getArtifactManager(new ArtifactManagerConfig());
         try (FeatureResolver fr = new FrameworkResolver(am, getFrameworkProps())) {
             assertEquals(Collections.emptyList(),
-                    fr.orderFeatures(Collections.emptyList()));
+                    fr.orderResources(Collections.emptyList()));
         }
     }
 
     @Test
-    public void testOrderFeatures() throws Exception {
+    public void testOrderResources() throws Exception {
         ArtifactManager am = ArtifactManager.getArtifactManager(new ArtifactManagerConfig());
 
         Feature f1 = readFeature("/feature1.json", am);
         Feature f2 = readFeature("/feature2.json", am);
         Feature f3 = readFeature("/feature3.json", am);
 
+        StringBuilder expectedBundles = new StringBuilder();
+        expectedBundles.append("slf4j.simple 1.7.25\n");
+        expectedBundles.append("slf4j.api 1.7.25\n");
+        expectedBundles.append("org.apache.sling.commons.logservice 1.0.6\n");
+        expectedBundles.append("org.apache.commons.io 2.6.0\n");
+        expectedBundles.append("org.apache.felix.http.servlet-api 1.1.2\n");
+
+        StringBuilder expectedResources = new StringBuilder();
+        expectedResources.append("feature3 1.0.0\n");
+        expectedResources.append("feature2 1.0.0\n");
+        expectedResources.append("feature1 1.0.0\n");
+
+        StringBuilder actualBundles = new StringBuilder();
+        StringBuilder actualResources = new StringBuilder();
         try (FeatureResolver fr = new FrameworkResolver(am, getFrameworkProps())) {
-            List<Feature> ordered = fr.orderFeatures(Arrays.asList(f1, f2, f3));
-            List<Feature> expected = Arrays.asList(f3, f2, f1);
-            assertEquals(expected, ordered);
+            for(FeatureResource ordered : fr.orderResources(Arrays.asList(f1, f2, f3))) {
+                if (IdentityNamespace.TYPE_BUNDLE.equals(
+                        ordered.getCapabilities(IdentityNamespace.IDENTITY_NAMESPACE).iterator().next().
+                        getAttributes().get(IdentityNamespace.CAPABILITY_TYPE_ATTRIBUTE))) {
+                    actualBundles.append(ordered.getId() + " " + ordered.getVersion() + "\n");
+                } else {
+                    actualResources.append(ordered.getId() + " " + ordered.getVersion() + "\n");
+                }
+            }
         }
+        assertEquals(expectedBundles.toString(), actualBundles.toString());
+        assertEquals(expectedResources.toString(), actualResources.toString());
+    }
+
+    @Test
+    public void testOrderResourcesWithFeatureProvidingCapability() throws Exception {
+        ArtifactManager am = ArtifactManager.getArtifactManager(new ArtifactManagerConfig());
+
+        Feature f4 = readFeature("/feature4.json", am);
+        Feature f5 = readFeature("/feature5.json", am);
+        Feature f6 = readFeature("/feature6.json", am);
+
+        StringBuilder expectedResources = new StringBuilder();
+        expectedResources.append("feature5 1.0.0\n");
+        expectedResources.append("feature4 1.0.0\n");
+        expectedResources.append("org.apache.sling.commons.logservice 1.0.6\n");
+        expectedResources.append("org.apache.felix.http.servlet-api 1.1.2\n");
+        expectedResources.append("feature6 1.0.0\n");
+        expectedResources.append("org.apache.commons.io 2.6.0\n");
+
+        StringBuilder actualResources = new StringBuilder();
+        try (FeatureResolver fr = new FrameworkResolver(am, getFrameworkProps())) {
+            for(FeatureResource ordered : fr.orderResources(Arrays.asList(f4, f5, f6))) {
+                actualResources.append(ordered.getId() + " " + ordered.getVersion() + "\n");
+            }
+        }
+        assertEquals(expectedResources.toString(), actualResources.toString());
     }
 
     private Feature readFeature(final String res,

--- a/featuremodel/feature-resolver/src/test/java/org/apache/sling/feature/resolver/impl/BundleResourceImplTest.java
+++ b/featuremodel/feature-resolver/src/test/java/org/apache/sling/feature/resolver/impl/BundleResourceImplTest.java
@@ -16,9 +16,24 @@
  */
 package org.apache.sling.feature.resolver.impl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import org.apache.sling.feature.Artifact;
+import org.apache.sling.feature.ArtifactId;
+import org.apache.sling.feature.Feature;
+import org.apache.sling.feature.FeatureResource;
+import org.apache.sling.feature.OSGiCapability;
+import org.apache.sling.feature.OSGiRequirement;
+import org.apache.sling.feature.analyser.BundleDescriptor;
+import org.apache.sling.feature.analyser.Descriptor;
+import org.apache.sling.feature.analyser.impl.BundleDescriptorImpl;
+import org.apache.sling.feature.support.util.PackageInfo;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.osgi.framework.Version;
+import org.osgi.framework.namespace.BundleNamespace;
+import org.osgi.framework.namespace.PackageNamespace;
+import org.osgi.resource.Capability;
+import org.osgi.resource.Requirement;
+import org.osgi.resource.Resource;
 
 import java.lang.reflect.Field;
 import java.util.Arrays;
@@ -29,21 +44,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.sling.feature.Artifact;
-import org.apache.sling.feature.ArtifactId;
-import org.apache.sling.feature.OSGiCapability;
-import org.apache.sling.feature.OSGiRequirement;
-import org.apache.sling.feature.analyser.BundleDescriptor;
-import org.apache.sling.feature.analyser.Descriptor;
-import org.apache.sling.feature.analyser.impl.BundleDescriptorImpl;
-import org.apache.sling.feature.support.util.PackageInfo;
-import org.junit.Test;
-import org.osgi.framework.Version;
-import org.osgi.framework.namespace.BundleNamespace;
-import org.osgi.framework.namespace.PackageNamespace;
-import org.osgi.resource.Capability;
-import org.osgi.resource.Requirement;
-import org.osgi.resource.Resource;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 public class BundleResourceImplTest {
     @Test
@@ -64,7 +68,9 @@ public class BundleResourceImplTest {
         Requirement r1 = new OSGiRequirement("ns.1",
                 Collections.emptyMap(), Collections.singletonMap("mydir", "myvalue"));
         List<Requirement> reqList = Collections.singletonList(r1);
-        Resource res = new BundleResourceImpl(caps,
+        Artifact art = Mockito.mock(Artifact.class);
+        Feature feat = Mockito.mock(Feature.class);
+        FeatureResource res = new BundleResourceImpl("a.b.c", "1.2.3", art, feat, caps,
                 Collections.singletonMap("ns.1", reqList));
 
         assertEquals(0, res.getCapabilities("nonexistent").size());
@@ -77,6 +83,11 @@ public class BundleResourceImplTest {
         assertTrue(mergedCaps.containsAll(capLst1));
         assertTrue(mergedCaps.containsAll(capLst2));
         assertEquals(reqList, res.getRequirements(null));
+
+        assertEquals("a.b.c", res.getId());
+        assertEquals(new Version("1.2.3"), res.getVersion());
+        assertSame(art, res.getArtifact());
+        assertSame(feat, res.getFeature());
     }
 
     @Test
@@ -96,7 +107,7 @@ public class BundleResourceImplTest {
         bd.getImportedPackages().add(im1);
         bd.getImportedPackages().add(im2);
 
-        Resource res = new BundleResourceImpl(bd);
+        Resource res = new BundleResourceImpl(bd, null);
         assertNotNull(
                 getCapAttribute(res, BundleNamespace.BUNDLE_NAMESPACE, BundleNamespace.BUNDLE_NAMESPACE));
         assertEquals(new Version("1.2.3"),
@@ -155,7 +166,7 @@ public class BundleResourceImplTest {
         Set<Requirement> reqs = new HashSet<>(Arrays.asList(req1, req2));
         BundleDescriptorImpl bd = new BundleDescriptorImpl(artifact, Collections.emptySet(), reqs, caps);
 
-        Resource res = new BundleResourceImpl(bd);
+        Resource res = new BundleResourceImpl(bd, null);
 
         assertEquals(caps, new HashSet<>(res.getCapabilities("org.example.cap1")));
         assertEquals(Collections.singleton(req1),

--- a/featuremodel/feature-resolver/src/test/java/org/apache/sling/feature/resolver/impl/ResolveContextImplTest.java
+++ b/featuremodel/feature-resolver/src/test/java/org/apache/sling/feature/resolver/impl/ResolveContextImplTest.java
@@ -16,11 +16,6 @@
  */
 package org.apache.sling.feature.resolver.impl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -40,10 +35,15 @@ import org.osgi.resource.Resource;
 import org.osgi.service.resolver.HostedCapability;
 import org.osgi.service.resolver.ResolveContext;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
 public class ResolveContextImplTest {
     @Test
     public void testMandatory() {
-        Resource mainRes = new BundleResourceImpl(Collections.emptyMap(), Collections.emptyMap());
+        Resource mainRes = new BundleResourceImpl("a", "1", null, null, Collections.emptyMap(), Collections.emptyMap());
         List<Resource> available = Arrays.asList();
         ResolveContext ctx = new ResolveContextImpl(mainRes, available);
 
@@ -57,7 +57,7 @@ public class ResolveContextImplTest {
         Resource res3 = exportBundle("org.foo", "1.0.0.TESTING");
         Resource res4 = exportBundle("org.foo", "1.9");
 
-        Resource mainRes = new BundleResourceImpl(Collections.emptyMap(), Collections.emptyMap());
+        Resource mainRes = new BundleResourceImpl("b", "2", null, null, Collections.emptyMap(), Collections.emptyMap());
         List<Resource> available = Arrays.asList(res1, res2, res3, res4);
         ResolveContext ctx = new ResolveContextImpl(mainRes, available);
 
@@ -79,7 +79,7 @@ public class ResolveContextImplTest {
         attrs.put(PackageNamespace.CAPABILITY_VERSION_ATTRIBUTE, new Version(version));
         Capability cap = new OSGiCapability(PackageNamespace.PACKAGE_NAMESPACE,
                 attrs, Collections.emptyMap());
-        return new BundleResourceImpl(
+        return new BundleResourceImpl("c", "3", null, null,
                 Collections.singletonMap(PackageNamespace.PACKAGE_NAMESPACE,
                         Collections.singletonList(cap)),
                 Collections.emptyMap());

--- a/featuremodel/feature-resolver/src/test/resources/feature4.json
+++ b/featuremodel/feature-resolver/src/test/resources/feature4.json
@@ -1,0 +1,5 @@
+{
+    "id": "org.apache.sling.test.features/feature4/1.0.0",
+    "bundles": 
+        ["org.apache.sling/org.apache.sling.commons.logservice/1.0.6"]
+}

--- a/featuremodel/feature-resolver/src/test/resources/feature5.json
+++ b/featuremodel/feature-resolver/src/test/resources/feature5.json
@@ -1,0 +1,13 @@
+{
+    "id": "org.apache.sling.test.features/feature5/1.0.0",
+    "capabilities": [
+        {
+            "namespace": "osgi.wiring.package",
+            "attributes": {
+                "osgi.wiring.package": "org.slf4j",
+                "version:Version": "1.7.2"
+            }
+        }
+    ],
+    "bundles": ["org.apache.felix/org.apache.felix.http.servlet-api/1.1.2"] 
+}

--- a/featuremodel/feature-resolver/src/test/resources/feature6.json
+++ b/featuremodel/feature-resolver/src/test/resources/feature6.json
@@ -1,0 +1,12 @@
+{
+    "id": "org.apache.sling.test.features/feature6/1.0.0",
+    "requirements": [
+        {
+            "namespace": "osgi.wiring.package",
+            "directives": {
+                "filter": "(&(osgi.wiring.package=org.slf4j)(version>=1.5.0)(!(version>=2.0.0)))"
+            }
+        }
+    ],
+    "bundles": ["commons-io/commons-io/2.6"]
+}

--- a/featuremodel/feature-support/src/test/resources/features/test.json
+++ b/featuremodel/feature-support/src/test/resources/features/test.json
@@ -63,19 +63,19 @@
             {
               "id" : "org.apache.sling/oak-server/1.0.0",
               "hash" : "4632463464363646436",
-              "startOrder" : 1
+              "start-order" : 1
             },
             {
               "id" : "org.apache.sling/application-bundle/2.0.0",
-              "startOrder" : 1
+              "start-order" : 1
             },
             {
               "id" : "org.apache.sling/another-bundle/2.1.0",
-              "startOrder" : 1
+              "start-order" : 1
             },
             {
               "id" : "org.apache.sling/foo-xyz/1.2.3",
-              "startOrder" : 2
+              "start-order" : 2
             }
     ],
     "configurations" : {

--- a/featuremodel/feature/src/main/java/org/apache/sling/feature/FeatureResource.java
+++ b/featuremodel/feature/src/main/java/org/apache/sling/feature/FeatureResource.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.sling.feature;
+
+import org.osgi.framework.Version;
+import org.osgi.resource.Resource;
+
+/**
+ * A Resource that is associated with an Maven Artifact and belongs to a Feature.
+ */
+public interface FeatureResource extends Resource {
+    /**
+     * Obtain the ID of the resource. If the resource is a bundle then this
+     * is the bundle symbolic name.
+     * @return The ID of the resource.
+     */
+    String getId();
+
+    /**
+     * Obtain the version of the resource.
+     * @return The version of the resource.
+     */
+    Version getVersion();
+
+    /**
+     * Obtain the associated (Maven) Artifact.
+     * @return The artifact for this Resource.
+     */
+    Artifact getArtifact();
+
+    /**
+     * Obtain the feature that contains this resource.
+     * @return The feature that contains the resource.
+     */
+    Feature getFeature();
+}

--- a/featuremodel/feature/src/main/java/org/apache/sling/feature/process/FeatureResolver.java
+++ b/featuremodel/feature/src/main/java/org/apache/sling/feature/process/FeatureResolver.java
@@ -19,20 +19,21 @@ package org.apache.sling.feature.process;
 import java.util.List;
 
 import org.apache.sling.feature.Feature;
+import org.apache.sling.feature.FeatureResource;
 
 /**
  * A resolver that can perform operations on the feature model.
  */
 public interface FeatureResolver extends AutoCloseable {
     /**
-     * Order the features by their dependency chain. Each feature and its
-     * components are resolved and each other feature providing the capabilities
-     * needed by the feature is placed before the requiring feature in the
-     * result.
+     * Order the resources in list of features by their dependency chain.
+     * Each feature and its components are resolved. Then all the resources
+     * in the feature are ordered so that each resource is placed before
+     * the requiring feature/resources in the result.
      *
      * @param features
      *            The features to order.
-     * @return The ordered features.
+     * @return The ordered resources from the features.
      */
-    List<Feature> orderFeatures(List<Feature> features);
+    List<FeatureResource> orderResources(List<Feature> features);
 }


### PR DESCRIPTION
Order resource (bundles and features) in the resulting application based on the order
of resolved features and then also in the order of the start order within the feature.

This pull request replaces previous pull request:  https://github.com/apache/sling-whiteboard/pull/7 