### PR TITLE
Initial variable support on the feature level

### DIFF
--- a/featuremodel/feature-support/src/main/java/org/apache/sling/feature/support/json/FeatureJSONReader.java
+++ b/featuremodel/feature-support/src/main/java/org/apache/sling/feature/support/json/FeatureJSONReader.java
@@ -46,6 +46,8 @@ import static org.apache.sling.feature.support.util.ManifestUtil.unmarshalDirect
  * This class offers a method to read a {@code Feature} using a {@code Reader} instance.
  */
 public class FeatureJSONReader extends JSONReaderBase {
+    // The pattern that variables in Feature JSON follow
+    private static final Pattern VARIABLE_PATTERN = Pattern.compile("\\$\\{[a-zA-Z0-9.-_]+\\}");
 
     /**
      * Read a new feature from the reader
@@ -160,8 +162,7 @@ public class FeatureJSONReader extends JSONReaderBase {
 
         String textWithVars = (String) value;
 
-        Pattern p = Pattern.compile("\\$\\{[a-zA-Z0-9.-_]+\\}");
-        Matcher m = p.matcher(textWithVars.toString());
+        Matcher m = VARIABLE_PATTERN.matcher(textWithVars.toString());
         StringBuffer sb = new StringBuffer();
         while (m.find()) {
             String var = m.group();

--- a/featuremodel/feature-support/src/main/java/org/apache/sling/feature/support/json/FeatureJSONReader.java
+++ b/featuremodel/feature-support/src/main/java/org/apache/sling/feature/support/json/FeatureJSONReader.java
@@ -16,21 +16,6 @@
  */
 package org.apache.sling.feature.support.json;
 
-import static org.apache.sling.feature.support.util.LambdaUtil.rethrowBiConsumer;
-import static org.apache.sling.feature.support.util.ManifestUtil.unmarshalAttribute;
-import static org.apache.sling.feature.support.util.ManifestUtil.unmarshalDirective;
-
-import java.io.IOException;
-import java.io.Reader;
-import java.io.StringReader;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import javax.json.Json;
-import javax.json.JsonObject;
-
 import org.apache.felix.configurator.impl.json.JSONUtil;
 import org.apache.sling.feature.ArtifactId;
 import org.apache.sling.feature.Feature;
@@ -39,6 +24,23 @@ import org.apache.sling.feature.OSGiCapability;
 import org.apache.sling.feature.OSGiRequirement;
 import org.osgi.resource.Capability;
 import org.osgi.resource.Requirement;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+
+import static org.apache.sling.feature.support.util.LambdaUtil.rethrowBiConsumer;
+import static org.apache.sling.feature.support.util.ManifestUtil.unmarshalAttribute;
+import static org.apache.sling.feature.support.util.ManifestUtil.unmarshalDirective;
 
 /**
  * This class offers a method to read a {@code Feature} using a {@code Reader} instance.
@@ -87,12 +89,15 @@ public class FeatureJSONReader extends JSONReaderBase {
     /** The provided id. */
     private final ArtifactId providedId;
 
+    /** The variables from the JSON. */
+    private Map<String, String> variables;
+
     /**
      * Private constructor
      * @param pId Optional id
      * @param location Optional location
      */
-    private FeatureJSONReader(final ArtifactId pId, final String location) {
+    FeatureJSONReader(final ArtifactId pId, final String location) {
         super(location);
         this.providedId = pId;
     }
@@ -130,6 +135,8 @@ public class FeatureJSONReader extends JSONReaderBase {
         this.feature.setVendor(getProperty(map, JSONConstants.FEATURE_VENDOR));
         this.feature.setLicense(getProperty(map, JSONConstants.FEATURE_LICENSE));
 
+        this.variables = this.readVariables(map);
+
         this.readBundles(map, feature.getBundles(), feature.getConfigurations());
         this.readFrameworkProperties(map, feature.getFrameworkProperties());
         this.readConfigurations(map, feature.getConfigurations());
@@ -143,6 +150,54 @@ public class FeatureJSONReader extends JSONReaderBase {
                 this.feature.getExtensions(), this.feature.getConfigurations());
 
         return feature;
+    }
+
+    @Override
+    protected Object handleVars(Object value) {
+        if (!(value instanceof String)) {
+            return value;
+        }
+
+        String textWithVars = (String) value;
+
+        Pattern p = Pattern.compile("\\$\\{[a-zA-Z0-9.-_]+\\}");
+        Matcher m = p.matcher(textWithVars.toString());
+        StringBuffer sb = new StringBuffer();
+        while (m.find()) {
+            String var = m.group();
+
+            int len = var.length();
+            String name = var.substring(2, len - 1);
+            String val = variables.get(name);
+            if (val != null) {
+                m.appendReplacement(sb, Matcher.quoteReplacement(val));
+            } else {
+                throw new IllegalStateException("Undefined variable: " + name);
+            }
+        }
+        m.appendTail(sb);
+
+        return sb.toString();
+    }
+
+    private Map<String, String> readVariables(Map<String, Object> map) throws IOException {
+        Map<String, String> varMap = new HashMap<>();
+
+        if (map.containsKey(JSONConstants.FEATURE_VARIABLES)) {
+            final Object variablesObj = map.get(JSONConstants.FEATURE_VARIABLES);
+            checkType(JSONConstants.FEATURE_VARIABLES, variablesObj, Map.class);
+
+            @SuppressWarnings("unchecked")
+            final Map<String, Object> vars = (Map<String, Object>) variablesObj;
+            for (final Map.Entry<String, Object> entry : vars.entrySet()) {
+                checkType("variable value", entry.getValue(), String.class, Boolean.class, Number.class);
+                if (varMap.get(entry.getKey()) != null) {
+                    throw new IOException(this.exceptionPrefix + "Duplicate variable " + entry.getKey());
+                }
+                varMap.put(entry.getKey(), "" + entry.getValue());
+            }
+        }
+        return varMap;
     }
 
     private void readIncludes(final Map<String, Object> map) throws IOException {
@@ -165,7 +220,7 @@ public class FeatureJSONReader extends JSONReaderBase {
                         throw new IOException(exceptionPrefix + " include is missing required artifact id");
                     }
                     checkType("Include " + JSONConstants.ARTIFACT_ID, obj.get(JSONConstants.ARTIFACT_ID), String.class);
-                    final ArtifactId id = ArtifactId.parse(obj.get(JSONConstants.ARTIFACT_ID).toString());
+                    final ArtifactId id = ArtifactId.parse(handleVars(obj.get(JSONConstants.ARTIFACT_ID)).toString());
                     include = new Include(id);
 
                     if ( obj.containsKey(JSONConstants.INCLUDE_REMOVALS) ) {
@@ -263,7 +318,7 @@ public class FeatureJSONReader extends JSONReaderBase {
                     checkType("Requirement attributes", obj.get(JSONConstants.REQCAP_ATTRIBUTES), Map.class);
                     @SuppressWarnings("unchecked")
                     final Map<String, Object> attrs = (Map<String, Object>)obj.get(JSONConstants.REQCAP_ATTRIBUTES);
-                    attrs.forEach(rethrowBiConsumer((key, value) -> unmarshalAttribute(key, value, attrMap::put)));
+                    attrs.forEach(rethrowBiConsumer((key, value) -> unmarshalAttribute(key, handleVars(value), attrMap::put)));
                 }
 
                 Map<String, String> dirMap = new HashMap<>();
@@ -271,10 +326,10 @@ public class FeatureJSONReader extends JSONReaderBase {
                     checkType("Requirement directives", obj.get(JSONConstants.REQCAP_DIRECTIVES), Map.class);
                     @SuppressWarnings("unchecked")
                     final Map<String, Object> dirs = (Map<String, Object>)obj.get(JSONConstants.REQCAP_DIRECTIVES);
-                    dirs.forEach(rethrowBiConsumer((key, value) -> unmarshalDirective(key, value, dirMap::put)));
+                    dirs.forEach(rethrowBiConsumer((key, value) -> unmarshalDirective(key, handleVars(value), dirMap::put)));
                 }
 
-                final Requirement r = new OSGiRequirement(obj.get(JSONConstants.REQCAP_NAMESPACE).toString(), attrMap, dirMap);
+                final Requirement r = new OSGiRequirement(handleVars(obj.get(JSONConstants.REQCAP_NAMESPACE)).toString(), attrMap, dirMap);
                 feature.getRequirements().add(r);
             }
         }
@@ -302,7 +357,7 @@ public class FeatureJSONReader extends JSONReaderBase {
                     checkType("Capability attributes", obj.get(JSONConstants.REQCAP_ATTRIBUTES), Map.class);
                     @SuppressWarnings("unchecked")
                     final Map<String, Object> attrs = (Map<String, Object>)obj.get(JSONConstants.REQCAP_ATTRIBUTES);
-                    attrs.forEach(rethrowBiConsumer((key, value) -> unmarshalAttribute(key, value, attrMap::put)));
+                    attrs.forEach(rethrowBiConsumer((key, value) -> unmarshalAttribute(key, handleVars(value), attrMap::put)));
                 }
 
                 Map<String, String> dirMap = new HashMap<>();
@@ -310,10 +365,10 @@ public class FeatureJSONReader extends JSONReaderBase {
                     checkType("Capability directives", obj.get(JSONConstants.REQCAP_DIRECTIVES), Map.class);
                     @SuppressWarnings("unchecked")
                     final Map<String, Object> dirs = (Map<String, Object>) obj.get(JSONConstants.REQCAP_DIRECTIVES);
-                    dirs.forEach(rethrowBiConsumer((key, value) -> unmarshalDirective(key, value, dirMap::put)));
+                    dirs.forEach(rethrowBiConsumer((key, value) -> unmarshalDirective(key, handleVars(value), dirMap::put)));
                 }
 
-                final Capability c = new OSGiCapability(obj.get(JSONConstants.REQCAP_NAMESPACE).toString(), attrMap, dirMap);
+                final Capability c = new OSGiCapability(handleVars(obj.get(JSONConstants.REQCAP_NAMESPACE)).toString(), attrMap, dirMap);
                 feature.getCapabilities().add(c);
             }
         }

--- a/featuremodel/feature-support/src/main/java/org/apache/sling/feature/support/json/JSONConstants.java
+++ b/featuremodel/feature-support/src/main/java/org/apache/sling/feature/support/json/JSONConstants.java
@@ -16,14 +16,16 @@
  */
 package org.apache.sling.feature.support.json;
 
+import org.apache.sling.feature.Configuration;
+
 import java.util.Arrays;
 import java.util.List;
-
-import org.apache.sling.feature.Configuration;
 
 public abstract class JSONConstants {
 
     public static final String FEATURE_ID = "id";
+
+    public static final String FEATURE_VARIABLES = "variables";
 
     public static final String FEATURE_BUNDLES = "bundles";
 
@@ -46,6 +48,7 @@ public abstract class JSONConstants {
     public static final String FEATURE_LICENSE = "license";
 
     public static final List<String> FEATURE_KNOWN_PROPERTIES = Arrays.asList(FEATURE_ID,
+            FEATURE_VARIABLES,
             FEATURE_BUNDLES,
             FEATURE_FRAMEWORK_PROPERTIES,
             FEATURE_CONFIGURATIONS,

--- a/featuremodel/feature-support/src/main/java/org/apache/sling/feature/support/json/JSONReaderBase.java
+++ b/featuremodel/feature-support/src/main/java/org/apache/sling/feature/support/json/JSONReaderBase.java
@@ -16,6 +16,20 @@
  */
 package org.apache.sling.feature.support.json;
 
+import org.apache.felix.configurator.impl.json.JSMin;
+import org.apache.felix.configurator.impl.json.JSONUtil;
+import org.apache.felix.configurator.impl.json.TypeConverter;
+import org.apache.felix.configurator.impl.model.Config;
+import org.apache.sling.feature.Artifact;
+import org.apache.sling.feature.ArtifactId;
+import org.apache.sling.feature.Bundles;
+import org.apache.sling.feature.Configuration;
+import org.apache.sling.feature.Configurations;
+import org.apache.sling.feature.Extension;
+import org.apache.sling.feature.ExtensionType;
+import org.apache.sling.feature.Extensions;
+import org.apache.sling.feature.KeyValueMap;
+
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringWriter;
@@ -33,20 +47,6 @@ import javax.json.JsonArrayBuilder;
 import javax.json.JsonObjectBuilder;
 import javax.json.JsonStructure;
 import javax.json.JsonWriter;
-
-import org.apache.felix.configurator.impl.json.JSMin;
-import org.apache.felix.configurator.impl.json.JSONUtil;
-import org.apache.felix.configurator.impl.json.TypeConverter;
-import org.apache.felix.configurator.impl.model.Config;
-import org.apache.sling.feature.Artifact;
-import org.apache.sling.feature.ArtifactId;
-import org.apache.sling.feature.Bundles;
-import org.apache.sling.feature.Configuration;
-import org.apache.sling.feature.Configurations;
-import org.apache.sling.feature.Extension;
-import org.apache.sling.feature.ExtensionType;
-import org.apache.sling.feature.Extensions;
-import org.apache.sling.feature.KeyValueMap;
 
 /**
  * Common methods for JSON reading.
@@ -146,7 +146,7 @@ abstract class JSONReaderBase {
                     throw new IOException(exceptionPrefix + " " + artifactType + " is missing required artifact id");
                 }
                 checkType(artifactType + " " + JSONConstants.ARTIFACT_ID, bundleObj.get(JSONConstants.ARTIFACT_ID), String.class);
-                final ArtifactId id = ArtifactId.parse(bundleObj.get(JSONConstants.ARTIFACT_ID).toString());
+                final ArtifactId id = ArtifactId.parse(handleVars(bundleObj.get(JSONConstants.ARTIFACT_ID)).toString());
 
                 artifact = new Artifact(id);
                 for(final Map.Entry<String, Object> metadataEntry : bundleObj.entrySet()) {
@@ -164,6 +164,11 @@ abstract class JSONReaderBase {
             }
             artifacts.add(artifact);
         }
+    }
+
+    protected Object handleVars(Object val) {
+        // No variable substitution at this level, but subclasses can add this in
+        return val;
     }
 
     protected void addConfigurations(final Map<String, Object> map,
@@ -201,7 +206,7 @@ abstract class JSONReaderBase {
                     throw new IOException(exceptionPrefix + "Configuration must not define configurator property " + key);
                 }
                 final Object val = c.getProperties().get(key);
-                config.getProperties().put(key, val);
+                config.getProperties().put(key, handleVars(val));
             }
             if ( config.getProperties().get(Configuration.PROP_ARTIFACT) != null ) {
                 throw new IOException(exceptionPrefix + "Configuration must not define property " + Configuration.PROP_ARTIFACT);
@@ -241,7 +246,7 @@ abstract class JSONReaderBase {
                 if ( container.get(entry.getKey()) != null ) {
                     throw new IOException(this.exceptionPrefix + "Duplicate framework property " + entry.getKey());
                 }
-                container.put(entry.getKey(), entry.getValue().toString());
+                container.put(entry.getKey(), handleVars(entry.getValue()).toString());
             }
 
         }

--- a/featuremodel/feature-support/src/main/java/org/apache/sling/feature/support/json/JSONReaderBase.java
+++ b/featuremodel/feature-support/src/main/java/org/apache/sling/feature/support/json/JSONReaderBase.java
@@ -138,7 +138,7 @@ abstract class JSONReaderBase {
             final Artifact artifact;
             checkType(artifactType, entry, Map.class, String.class);
             if ( entry instanceof String ) {
-                artifact = new Artifact(ArtifactId.parse(entry.toString()));
+                artifact = new Artifact(ArtifactId.parse(handleVars(entry).toString()));
             } else {
                 @SuppressWarnings("unchecked")
                 final Map<String, Object> bundleObj = (Map<String, Object>) entry;

--- a/featuremodel/feature-support/src/test/java/org/apache/sling/feature/support/json/FeatureJSONReaderTest.java
+++ b/featuremodel/feature-support/src/test/java/org/apache/sling/feature/support/json/FeatureJSONReaderTest.java
@@ -105,6 +105,8 @@ public class FeatureJSONReaderTest {
         Bundles bundles = feature.getBundles();
         ArtifactId id = new ArtifactId("org.apache.sling", "foo-xyz", "1.2.3", null, null);
         assertTrue(bundles.containsExact(id));
+        ArtifactId id2 = new ArtifactId("org.apache.sling", "bar-xyz", "1.2.3", null, null);
+        assertTrue(bundles.containsExact(id2));
 
         Configurations configurations = feature.getConfigurations();
         Configuration config = configurations.getConfiguration("my.pid2");

--- a/featuremodel/feature-support/src/test/java/org/apache/sling/feature/support/json/FeatureJSONReaderTest.java
+++ b/featuremodel/feature-support/src/test/java/org/apache/sling/feature/support/json/FeatureJSONReaderTest.java
@@ -16,18 +16,32 @@
  */
 package org.apache.sling.feature.support.json;
 
+import org.apache.sling.feature.ArtifactId;
+import org.apache.sling.feature.Bundles;
 import org.apache.sling.feature.Configuration;
+import org.apache.sling.feature.Configurations;
 import org.apache.sling.feature.Extension;
 import org.apache.sling.feature.Extensions;
 import org.apache.sling.feature.Feature;
+import org.apache.sling.feature.Include;
+import org.apache.sling.feature.KeyValueMap;
 import org.junit.Test;
 import org.osgi.resource.Capability;
+import org.osgi.resource.Requirement;
 
+import java.lang.reflect.Field;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Dictionary;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class FeatureJSONReaderTest {
 
@@ -55,6 +69,51 @@ public class FeatureJSONReaderTest {
 
     }
 
+    @Test public void testReadWithVariables() throws Exception {
+        final Feature feature = U.readFeature("test2");
+
+        List<Include> includes = feature.getIncludes();
+        assertEquals(1, includes.size());
+        Include include = includes.get(0);
+        assertEquals("org.apache.sling:sling:9", include.getId().toMvnId());
+
+        List<Requirement> reqs = feature.getRequirements();
+        Requirement req = reqs.get(0);
+        assertEquals("osgi.contract", req.getNamespace());
+        assertEquals("(&(osgi.contract=JavaServlet)(&(version>=3.0)(!(version>=4.0))))",
+                req.getDirectives().get("filter"));
+
+        List<Capability> caps = feature.getCapabilities();
+        Capability cap = null;
+        for (Capability c : caps) {
+            if ("osgi.service".equals(c.getNamespace())) {
+                cap = c;
+                break;
+            }
+        }
+        assertEquals(Collections.singletonList("org.osgi.service.http.runtime.HttpServiceRuntime"),
+                cap.getAttributes().get("objectClass"));
+        assertEquals("org.osgi.service.http.runtime",
+                cap.getDirectives().get("uses"));
+        // TODO this seems quite broken: fix!
+        // assertEquals("org.osgi.service.http.runtime,org.osgi.service.http.runtime.dto",
+        //        cap.getDirectives().get("uses"));
+
+        KeyValueMap fwProps = feature.getFrameworkProperties();
+        assertEquals("something", fwProps.get("brave"));
+
+        Bundles bundles = feature.getBundles();
+        ArtifactId id = new ArtifactId("org.apache.sling", "foo-xyz", "1.2.3", null, null);
+        assertTrue(bundles.containsExact(id));
+
+        Configurations configurations = feature.getConfigurations();
+        Configuration config = configurations.getConfiguration("my.pid2");
+        Dictionary<String, Object> props = config.getProperties();
+        assertEquals("aaright!", props.get("a.value"));
+        assertEquals("right!bb", props.get("b.value"));
+        assertEquals("creally?c", props.get("c.value"));
+    }
+
     @Test public void testReadRepoInitExtension() throws Exception {
         Feature feature = U.readFeature("repoinit");
         Extensions extensions = feature.getExtensions();
@@ -69,5 +128,30 @@ public class FeatureJSONReaderTest {
         assertEquals(1, extensions.size());
         Extension ext = extensions.iterator().next();
         assertEquals("some repo init\ntext\n", ext.getText());
+    }
+
+    @Test public void testHandleVars() throws Exception {
+        FeatureJSONReader reader = new FeatureJSONReader(null, null);
+        Map<String, Object> vars = new HashMap<>();
+        vars.put("var1", "bar");
+        vars.put("varvariable", "${myvar}");
+        vars.put("var.2", "2");
+        setPrivateField(reader, "variables", vars);
+
+        assertEquals("foobarfoo", reader.handleVars("foo${var1}foo"));
+        assertEquals("barbarbar", reader.handleVars("${var1}${var1}${var1}"));
+        assertEquals("${}test${myvar}2", reader.handleVars("${}test${varvariable}${var.2}"));
+        try {
+            reader.handleVars("${undefined}");
+            fail("Should throw an exception on the undefined variable");
+        } catch (IllegalStateException ise) {
+            // good
+        }
+    }
+
+    private void setPrivateField(Object obj, String name, Object value) throws Exception {
+        Field field = obj.getClass().getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(obj, value);
     }
 }

--- a/featuremodel/feature-support/src/test/resources/features/test2.json
+++ b/featuremodel/feature-support/src/test/resources/features/test2.json
@@ -88,7 +88,8 @@
             {
               "id" : "org.apache.sling/foo-xyz/${common.version}",
               "start-order" : 2
-            }
+            },
+            "org.apache.sling/bar-xyz/${common.version}"
     ],
     "configurations" : {
         "my.pid" : {

--- a/featuremodel/feature-support/src/test/resources/features/test2.json
+++ b/featuremodel/feature-support/src/test/resources/features/test2.json
@@ -1,0 +1,105 @@
+{
+    "id" : "org.apache.sling/test2/1.1",
+
+    "variables": {
+         "common.version": "1.2.3",
+         "contract.name": "JavaServlet",
+         "ab_config": "right!",
+         "c_config": "really?",
+         "includever": "9",
+         "ns": "contract",
+         "sling.gid": "org.apache.sling",
+         "something": "something",
+         "svc": "service"
+    },
+
+    "includes" : [
+         {
+             "id" : "${sling.gid}/sling/${includever}",
+             "removals" : {
+                 "configurations" : [
+                 ],
+                 "bundles" : [
+                 ],
+                 "framework-properties" : [
+                 ]
+             }
+         }
+    ],
+    "requirements" : [
+          {
+              "namespace" : "osgi.${ns}",
+              "directives" : {
+                  "filter" : "(&(osgi.contract=${contract.name})(&(version>=3.0)(!(version>=4.0))))"
+              }
+          }
+    ],
+    "capabilities" : [
+        {
+             "namespace" : "osgi.implementation",
+             "attributes" : {
+                   "osgi.implementation" : "osgi.http",
+                   "version:Version" : "1.1"
+             },
+             "directives" : {
+                  "uses" : "javax.servlet,javax.servlet.http,org.osgi.service.http.context,org.osgi.service.http.whiteboard"
+             }
+        },
+        {
+             "namespace" : "osgi.${svc}",
+             "attributes" : {
+                  "objectClass:List<String>" : "org.osgi.${svc}.http.runtime.HttpServiceRuntime"
+             },
+             "directives" : {
+                  "uses" : "org.osgi.${svc}.http.runtime,org.osgi.${svc}.http.runtime.dto"
+             }
+        },
+        {
+          "namespace" : "osgi.contract",
+          "attributes" : {
+            "osgi.contract" : "JavaServlet",
+            "osgi.implementation" : "osgi.http",
+            "version:Version" : "3.1"
+          },
+          "directives" : {
+            "uses" : "org.osgi.service.http.runtime,org.osgi.service.http.runtime.dto"
+          }
+        }
+    ],
+    "framework-properties" : {
+        "foo" : 1,
+        "brave" : "${something}",
+        "org.apache.felix.scr.directory" : "launchpad/scr"
+    },
+    "bundles" :[
+            {
+              "id" : "org.apache.sling/oak-server/1.0.0",
+              "hash" : "4632463464363646436",
+              "start-order" : 1
+            },
+            {
+              "id" : "org.apache.sling/application-bundle/2.0.0",
+              "start-order" : 1
+            },
+            {
+              "id" : "org.apache.sling/another-bundle/2.1.0",
+              "start-order" : 1
+            },
+            {
+              "id" : "org.apache.sling/foo-xyz/${common.version}",
+              "start-order" : 2
+            }
+    ],
+    "configurations" : {
+        "my.pid" : {
+           "foo" : 5,
+           "bar" : "test",
+           "number:Integer" : 7
+        },
+        "my.pid2" : {
+           "a.value" : "aa${ab_config}",
+           "b.value" : "${ab_config}bb",
+           "c.value" : "c${c_config}c"
+        }
+    }
+}


### PR DESCRIPTION
This addresses SFM360 from requirements.md
As the substitution is handled centrally, it can also be disabled, which
can be useful when implementing SFM420.