### PR TITLE
First commit for oidc handler.

### DIFF
--- a/oidc-handler/core/src/main/java/org/apache/sling/oidchandler/core/configuration/OIDCConfigServlet.java
+++ b/oidc-handler/core/src/main/java/org/apache/sling/oidchandler/core/configuration/OIDCConfigServlet.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.sling.oidchandler.core.configuration;
+
+import org.apache.sling.api.servlets.SlingSafeMethodsServlet;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.metatype.annotations.Designate;
+
+import javax.servlet.Servlet;
+
+@Component( immediate = true, service = Servlet.class)
+@Designate(ocd = OIDCConfiguration.class)
+public class OIDCConfigServlet extends SlingSafeMethodsServlet {
+
+    private static OIDCConfiguration config;
+
+    @Activate
+    protected void Activate(OIDCConfiguration config) {
+        this.config = config;
+
+    }
+
+    public static Boolean getOIDCEnabled(){
+        return config.oidc_enable_boolean();
+    }
+
+    public static String getClientID(){
+        return config.clientid_string();
+    }
+
+    public static String getClientSecret(){
+        return config.clientsecret_password();
+    }
+
+    public static String getCallbackURL(){
+        return config.oidc_callback_url_string();
+    }
+
+    public static String getOIDCScope(){
+        return config.oidc_scope_string();
+    }
+
+    public static String getIssuerURL(){
+        return config.issuer_url_string();
+    }
+
+    public static String getAuthEndpoint(){
+        return config.authorization_endpoint_string();
+    }
+
+    public static String getTokenEndpoint(){
+        return config.token_endpoint_string();
+    }
+
+    public static String getUserinfoEndpoint(){
+        return config.userinfo_endpoint_string();
+    }
+
+    public static String getRevocationEndpoint(){
+        return config.revocation_endpoint_string();
+    }
+
+    public static String getJwksUri(){
+        return config.jwks_uri_string();
+    }
+
+}

--- a/oidc-handler/core/src/main/java/org/apache/sling/oidchandler/core/configuration/OIDCConfiguration.java
+++ b/oidc-handler/core/src/main/java/org/apache/sling/oidchandler/core/configuration/OIDCConfiguration.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.sling.oidchandler.core.configuration;
+
+import org.apache.sling.oidchandler.core.util.OPConstant;
+import org.osgi.service.metatype.annotations.AttributeDefinition;
+import org.osgi.service.metatype.annotations.AttributeType;
+import org.osgi.service.metatype.annotations.ObjectClassDefinition;
+import org.apache.commons.lang3.StringUtils;
+
+@ObjectClassDefinition(name = "Google - OpenID Connect Configuration")
+public @interface OIDCConfiguration {
+
+    @AttributeDefinition(
+            name = "Enable",
+            description = "Enable OpenID Connect Authentication Handler",
+            type = AttributeType.BOOLEAN
+    )
+    boolean oidc_enable_boolean() default true;
+
+    @AttributeDefinition(
+            name = "Client ID",
+            description = "Enter Client ID",
+            type = AttributeType.STRING
+
+    )
+    String clientid_string() default StringUtils.EMPTY;
+
+    @AttributeDefinition(
+            name = "Client Secret",
+            description = "Enter Client Secret",
+            type = AttributeType.PASSWORD
+    )
+    String clientsecret_password() default StringUtils.EMPTY;
+
+    @AttributeDefinition(
+            name = "Callback URL",
+            description = "Enter Callback URL",
+            type = AttributeType.STRING
+    )
+    String oidc_callback_url_string() default OPConstant.oidc_callback_url;
+
+    @AttributeDefinition(
+            name = "Scope",
+            description = "Enter scope",
+            type = AttributeType.STRING
+    )
+    String oidc_scope_string() default OPConstant.oidc_scope;
+
+
+    @AttributeDefinition(
+            name = "Issure",
+            description = "Issure Url of Google",
+            type = AttributeType.STRING
+    )
+    String issuer_url_string() default OPConstant.google_issuer_url;
+
+    @AttributeDefinition(
+            name = "Authorization Endpoint",
+            description = "Authorization Endpoint Url of Google",
+            type = AttributeType.STRING
+    )
+    String authorization_endpoint_string() default OPConstant.google_authorization_endpoint;
+
+    @AttributeDefinition(
+            name = "Token Endpoint",
+            description = "Token Endpoint Url of Google",
+            type = AttributeType.STRING
+    )
+    String token_endpoint_string() default OPConstant.google_token_endpoint;
+
+    @AttributeDefinition(
+            name = "Userinfo Endpoint",
+            description = "Userinfo Endpoint Url of Google",
+            type = AttributeType.STRING
+    )
+    String userinfo_endpoint_string() default OPConstant.google_userinfo_endpoint;
+
+    @AttributeDefinition(
+            name = "Revocation Endpoint",
+            description = "Revocation Endpoint Url of Google",
+            type = AttributeType.STRING
+    )
+    String revocation_endpoint_string() default OPConstant.google_revocation_endpoint;
+
+    @AttributeDefinition(
+            name = "JWKS URI",
+            description = "JWKS URI of Google",
+            type = AttributeType.STRING
+    )
+    String jwks_uri_string() default OPConstant.google_jwks_uri;
+
+}

--- a/oidc-handler/core/src/main/java/org/apache/sling/oidchandler/core/endpoints/ErrorEndpoint.java
+++ b/oidc-handler/core/src/main/java/org/apache/sling/oidchandler/core/endpoints/ErrorEndpoint.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.sling.oidchandler.core.endpoints;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.servlets.SlingAllMethodsServlet;
+import org.osgi.service.component.annotations.Component;
+
+import javax.servlet.Servlet;
+import java.io.IOException;
+
+
+@Component(service = Servlet.class, property = {"sling.servlet.methods={GET, POST}","sling.servlet.paths=/auth/login/error"},immediate = true)
+public class ErrorEndpoint extends SlingAllMethodsServlet{
+
+    @Override
+    protected void doGet(SlingHttpServletRequest request, SlingHttpServletResponse response) throws IOException {
+
+        response.getWriter().print("Error occured in Authentication process.");
+    }
+}

--- a/oidc-handler/core/src/main/java/org/apache/sling/oidchandler/core/endpoints/LoginEndpoint.java
+++ b/oidc-handler/core/src/main/java/org/apache/sling/oidchandler/core/endpoints/LoginEndpoint.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.sling.oidchandler.core.endpoints;
+
+import com.nimbusds.oauth2.sdk.ParseException;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.servlets.SlingAllMethodsServlet;
+import org.apache.sling.oidchandler.core.configuration.OIDCConfigServlet;
+import org.apache.sling.oidchandler.core.exception.AuthenticationError;
+import org.apache.sling.oidchandler.core.handlers.Handler;
+import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.Servlet;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+@Component(service = Servlet.class, property = {"sling.servlet.methods={GET, POST}","sling.servlet.paths=/auth/login"},immediate = true)
+public class LoginEndpoint extends SlingAllMethodsServlet {
+    private final Logger logger = LoggerFactory.getLogger(LoginEndpoint.class);
+
+    @Override
+    protected void doGet(SlingHttpServletRequest request, SlingHttpServletResponse response) throws IOException {
+
+        Boolean enabled = OIDCConfigServlet.getOIDCEnabled();
+
+        if (enabled) {
+            try {
+
+                URI uri = Handler.getHandler().createAuthenticationRequest();
+
+                if (uri != null) {
+                    response.setStatus(302);
+                    response.setHeader("Location",uri.toString());
+
+                } else {
+                    logger.info("Error occured while creating the Authentication request.");
+                    AuthenticationError.sendAuthenticationError(response);
+                }
+
+            } catch (URISyntaxException e) {
+                logger.info("Error occured while creating the Authentication request.");
+            } catch (ParseException e) {
+                logger.info("Error occured while creating the Authentication request.");
+            }
+        } else {
+            logger.info("OpenID Connect handler is not enabled in OSGI configurations.");
+            AuthenticationError.sendAuthenticationError(response);
+        }
+
+    }
+}

--- a/oidc-handler/core/src/main/java/org/apache/sling/oidchandler/core/exception/AuthenticationError.java
+++ b/oidc-handler/core/src/main/java/org/apache/sling/oidchandler/core/exception/AuthenticationError.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.sling.oidchandler.core.exception;
+
+import javax.servlet.http.HttpServletResponse;
+
+public class AuthenticationError {
+
+  public static void sendAuthenticationError(HttpServletResponse response) {
+
+      response.setStatus(302);
+      response.setHeader("Location","http://localhost:8080/auth/login/error");
+  }
+}

--- a/oidc-handler/core/src/main/java/org/apache/sling/oidchandler/core/handlers/Handler.java
+++ b/oidc-handler/core/src/main/java/org/apache/sling/oidchandler/core/handlers/Handler.java
@@ -1,0 +1,191 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.sling.oidchandler.core.handlers;
+
+import com.nimbusds.oauth2.sdk.*;
+import com.nimbusds.oauth2.sdk.auth.ClientSecretBasic;
+import com.nimbusds.oauth2.sdk.auth.Secret;
+import com.nimbusds.oauth2.sdk.http.HTTPResponse;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.oauth2.sdk.id.State;
+import com.nimbusds.openid.connect.sdk.*;
+import com.nimbusds.openid.connect.sdk.token.OIDCTokens;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.sling.oidchandler.core.configuration.OIDCConfigServlet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public class Handler {
+
+    private static Handler handler = null;
+    private static Object monitor = new Object();
+    private static final Logger log = LoggerFactory.getLogger(Handler.class);
+    private static final String stateValue = "Scope-8cf2f97-91cf-4639-b6c4-682a84a08d30";
+    private static final String nonceValue = "Nonce-2aa208-154e-4478-a431-ee6e6184c725";
+
+    private Handler(){
+
+    }
+
+    public static Handler getHandler(){
+        if (handler == null) {
+            synchronized (monitor) {
+                if (handler == null) {
+                    handler = new Handler();
+                }
+            }
+        }
+        return handler;
+    }
+
+    public static String getExpectedState() {
+        return stateValue;
+    }
+
+    public static String getExpectedNonce() {
+        return nonceValue;
+    }
+
+    public URI createAuthenticationRequest() throws URISyntaxException, ParseException {
+        //read OSGI Configuration
+        String oidcScope = OIDCConfigServlet.getOIDCScope();
+        String callBackUrl = OIDCConfigServlet.getCallbackURL();
+        String authEndpoint = OIDCConfigServlet.getAuthEndpoint();
+        String oidcClientID = OIDCConfigServlet.getClientID();
+
+        if (StringUtils.isNoneEmpty(oidcScope, callBackUrl, authEndpoint, oidcClientID)) {
+            // Generate random state string for pairing the response to the request
+            State state = new State(stateValue);
+            // Generate nonce
+            Nonce nonce = new Nonce(nonceValue);
+            // Specify scope
+            Scope scope = Scope.parse(oidcScope);
+
+            //Redirect URI
+            URI redirectURI = new URI(callBackUrl);
+
+            //Authorization Endpoint URI
+            URI authorizationEndpointURI = new URI(authEndpoint);
+
+            //ClientID
+            ClientID clientID = new ClientID(oidcClientID);
+
+            //Prompt value
+            Prompt prompt = new Prompt("consent");
+
+            Display display = Display.parse("page");
+
+            // Compose the request
+            AuthenticationRequest authenticationRequest = new AuthenticationRequest( authorizationEndpointURI,
+                new ResponseType(ResponseType.Value.CODE), null,
+                scope, clientID, redirectURI, state, nonce,
+                display, prompt, -1, null, null,
+                null, null, null, null, null,
+                null, null, null);
+
+            URI authReqURI = authenticationRequest.toURI();
+
+            return authReqURI;
+        }
+        return null;
+    }
+
+    public AuthorizationCode getAuthorizationCode(String requestURL){
+
+        AuthenticationResponse authResp = null;
+        AuthorizationCode authCode = null;
+
+        try {
+            authResp = AuthenticationResponseParser.parse(new URI(requestURL));
+        } catch (ParseException | URISyntaxException e) {
+            log.error(e.getMessage(), e);
+        }
+        if (authResp instanceof AuthenticationErrorResponse) {
+            ErrorObject error = ((AuthenticationErrorResponse) authResp).getErrorObject();
+            log.info(error.getDescription());
+        } else {
+            AuthenticationSuccessResponse successResponse = (AuthenticationSuccessResponse) authResp;
+            // Check state
+            if (verifyState(successResponse.getState().toString())) {
+                authCode = successResponse.getAuthorizationCode();
+
+            }
+        }
+        return  authCode;
+    }
+
+    public TokenRequest createTokenRequest(AuthorizationCode authCode) throws URISyntaxException {
+
+        //read OSGI Configuration
+        String oidcClientSecret = OIDCConfigServlet.getClientSecret();
+        String tokenEndpoint = OIDCConfigServlet.getTokenEndpoint();
+        String oidcClientID = OIDCConfigServlet.getClientID();
+        String callBackUrl = OIDCConfigServlet.getCallbackURL();
+
+        if (StringUtils.isNoneEmpty(oidcClientID, oidcClientSecret, tokenEndpoint, callBackUrl)) {
+            //Token Endpoint URI
+            URI tokenEndpointURI = new URI(tokenEndpoint);
+
+            //ClientID
+            ClientID clientID = new ClientID(oidcClientID);
+
+            //Client Secret
+            Secret clientSecret = new Secret(oidcClientSecret);
+
+            //Redirect URI
+            URI redirectURI = new URI(callBackUrl);
+
+            TokenRequest tokenReq = new TokenRequest(
+                    tokenEndpointURI,
+                    new ClientSecretBasic(clientID, clientSecret),
+                    new AuthorizationCodeGrant(authCode, redirectURI));
+            return tokenReq;
+
+        }
+        return null;
+
+    }
+
+    public OIDCTokens getOIDCTokens(HTTPResponse tokenHTTPResp) {
+
+        TokenResponse tokenResponse = null;
+        OIDCTokens oidcTokens = null;
+        try {
+            tokenResponse = OIDCTokenResponseParser.parse(tokenHTTPResp);
+        } catch (ParseException e) {
+            log.error(e.getMessage(), e);
+        }
+
+        if (tokenResponse instanceof TokenErrorResponse) {
+            ErrorObject error = ((TokenErrorResponse) tokenResponse).getErrorObject();
+            log.info(error.getDescription());
+        } else {
+            OIDCTokenResponse accessTokenResponse = (OIDCTokenResponse) tokenResponse;
+            oidcTokens = accessTokenResponse.getOIDCTokens();
+        }
+
+        return  oidcTokens;
+    }
+
+    private boolean verifyState(String state){
+        if (state.equals(getExpectedState())) {
+            return true;
+        }
+        return false;
+    }
+
+}

--- a/oidc-handler/core/src/main/java/org/apache/sling/oidchandler/core/handlers/IDTokenHandler.java
+++ b/oidc-handler/core/src/main/java/org/apache/sling/oidchandler/core/handlers/IDTokenHandler.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.sling.oidchandler.core.handlers;
+
+import com.nimbusds.jose.*;
+import com.nimbusds.jose.proc.BadJOSEException;
+import com.nimbusds.jose.proc.SecurityContext;
+import com.nimbusds.jwt.JWT;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.oauth2.sdk.id.Issuer;
+import com.nimbusds.openid.connect.sdk.Nonce;
+import com.nimbusds.openid.connect.sdk.claims.IDTokenClaimsSet;
+import com.nimbusds.openid.connect.sdk.validators.IDTokenValidator;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.sling.oidchandler.core.configuration.OIDCConfigServlet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+public class IDTokenHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(IDTokenHandler.class);
+
+    public IDTokenClaimsSet verifyIdToken(JWT idToken, String nonce) throws MalformedURLException {
+        //read OSGI Configuration
+        String issuer = OIDCConfigServlet.getIssuerURL();
+        String oidcClientID = OIDCConfigServlet.getClientID();
+        String jwksURI = OIDCConfigServlet.getJwksUri();
+
+       if (StringUtils.isNoneEmpty(issuer, oidcClientID, jwksURI)) {
+           // The required parameters
+           Issuer iss = new Issuer(issuer);
+           ClientID clientID = new ClientID(oidcClientID);
+           JWSAlgorithm jwsAlg = JWSAlgorithm.RS256;
+           URL jwkSetURL = new URL(jwksURI);
+
+           // Create validator for signed ID tokens
+           IDTokenValidator validator = new IDTokenValidator(iss, clientID, jwsAlg, jwkSetURL);
+
+           // Set the expected nonce
+           Nonce expectedNonce = new Nonce(nonce);
+
+           IDTokenClaimsSet claims = null;
+
+           try {
+               claims = validator.validate(idToken, expectedNonce);
+           } catch (BadJOSEException e) {
+               log.error(e.getMessage(), e);
+           } catch (JOSEException e) {
+               log.error(e.getMessage(), e);
+           }
+           return  claims;
+       }
+
+       return  null;
+    }
+
+}

--- a/oidc-handler/core/src/main/java/org/apache/sling/oidchandler/core/login/OIDCAuthenticationHandler.java
+++ b/oidc-handler/core/src/main/java/org/apache/sling/oidchandler/core/login/OIDCAuthenticationHandler.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.sling.oidchandler.core.login;
+
+import com.nimbusds.oauth2.sdk.AuthorizationCode;
+import com.nimbusds.oauth2.sdk.TokenRequest;
+import com.nimbusds.oauth2.sdk.http.HTTPResponse;
+import com.nimbusds.openid.connect.sdk.claims.IDTokenClaimsSet;
+import com.nimbusds.openid.connect.sdk.token.OIDCTokens;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.jackrabbit.api.security.user.User;
+import org.apache.sling.auth.core.spi.AuthenticationHandler;
+import org.apache.sling.auth.core.spi.AuthenticationInfo;
+import org.apache.sling.auth.core.spi.DefaultAuthenticationFeedbackHandler;
+import org.apache.sling.oidchandler.core.exception.AuthenticationError;
+import org.apache.sling.oidchandler.core.handlers.Handler;
+import org.apache.sling.oidchandler.core.handlers.IDTokenHandler;
+import org.apache.sling.oidchandler.core.user.UserManagerImpl;
+import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.jcr.Credentials;
+import javax.jcr.RepositoryException;
+import javax.jcr.SimpleCredentials;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+@Component(
+        service = AuthenticationHandler.class ,
+        name = "OIDC Authentication Handler",
+        property = {"sling.servlet.methods={GET, POST}", AuthenticationHandler.PATH_PROPERTY+"=/", },
+        immediate = true)
+
+public class OIDCAuthenticationHandler extends DefaultAuthenticationFeedbackHandler implements AuthenticationHandler {
+
+    private final Logger logger = LoggerFactory.getLogger(OIDCAuthenticationHandler.class);
+
+    private static final String AUTHENTICATION_SCHEME_OIDC = "OIDC";
+
+    private String username="";
+
+    private String password ="";
+
+    @Override
+    public AuthenticationInfo extractCredentials(HttpServletRequest request, HttpServletResponse response) {
+        // extract credentials and return
+
+        String requestScope = request.getParameter("code");
+
+        String requestURI = request.getRequestURI();
+
+        if (StringUtils.isNotEmpty(requestScope) && StringUtils.isEmpty(username)) {
+
+            AuthenticationInfo info = null;
+            try {
+                info = oidcLogin(request,response);
+            } catch (IOException e) {
+                logger.info("Error occurred when extracting credentials.");
+            }
+            if (info != null) {
+                return info;
+            }
+        }
+
+        if (requestURI.equals("/system/sling/logout")) {
+            username = "";
+            password ="";
+        }
+
+        return new AuthenticationInfo(AUTHENTICATION_SCHEME_OIDC, username, password.toCharArray());
+    }
+
+    @Override
+    public boolean requestCredentials(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) throws IOException {
+        try {
+            httpServletResponse.getWriter().print("Request");
+        } catch (IOException e) {
+            logger.info("Error occurred when requesting credentials.");
+        }
+        return false;
+    }
+
+    @Override
+    public void dropCredentials(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) throws IOException {
+        try {
+            httpServletResponse.getWriter().print("Drop");
+        } catch (IOException e) {
+            logger.info("Error occurred when dropping credentials.");
+        }
+    }
+
+    protected AuthenticationInfo oidcLogin(HttpServletRequest request, HttpServletResponse response) throws IOException {
+
+            String responseURL = request.getRequestURL().toString()+"?"+request.getQueryString();
+
+            AuthorizationCode authorizationCode = Handler.getHandler().getAuthorizationCode(responseURL);
+
+            if (authorizationCode != null) {
+
+                try {
+
+                    TokenRequest tokenRequest = Handler.getHandler().createTokenRequest(authorizationCode);
+
+                    if (tokenRequest != null) {
+                        HTTPResponse httpResponse = tokenRequest.toHTTPRequest().send();
+                        OIDCTokens oidcTokens = Handler.getHandler().getOIDCTokens(httpResponse);
+
+                        if (oidcTokens != null) {
+
+                            String expectedNonce = Handler.getHandler().getExpectedNonce();
+
+                            if (StringUtils.isNotEmpty(expectedNonce)) {
+                                IDTokenHandler idTokenHandler = new IDTokenHandler();
+                                IDTokenClaimsSet claimsSet = idTokenHandler.verifyIdToken(oidcTokens.getIDToken(), expectedNonce);
+
+                                if (claimsSet != null) {
+
+                                    String userID = (String) claimsSet.getClaim("email");
+
+                                    if (StringUtils.isNotEmpty(userID)) {
+
+                                        UserManagerImpl userManager = new UserManagerImpl();
+                                        String userPassword = "";
+                                        Credentials credentials = new SimpleCredentials(userID, userPassword.toCharArray());
+                                        User user = userManager.getUser(credentials);
+
+                                        if (user == null) {
+                                            try {
+                                                userManager.createUser(userID, userPassword);
+                                                logger.info("User "+userID + " is created.\n User "+userID+" successfully logged in.");
+
+                                            } catch (RepositoryException e) {
+                                                logger.info("Error occurred when creating a user.");
+                                            }
+                                        } else {
+                                            logger.info("User "+userID+ " already exist.\n User "+userID+" successfully logged in.");
+
+                                        }
+
+                                        username = userID;
+                                        password = userPassword;
+
+                                        return new AuthenticationInfo(AUTHENTICATION_SCHEME_OIDC, userID, userPassword.toCharArray());
+
+                                    }
+
+                                } else {
+                                    logger.info("ID_Token verification has failed.");
+                                    AuthenticationError.sendAuthenticationError(response);
+                                }
+
+                            } else {
+                                logger.info("Expected nonce is different from the actual nonce value.");
+                                AuthenticationError.sendAuthenticationError(response);
+                            }
+                        }
+
+                    } else {
+                        logger.info("Error occurred when creating the token request.");
+                        AuthenticationError.sendAuthenticationError(response);
+
+                    }
+
+                } catch (URISyntaxException e) {
+                    logger.info("Error occurred when creating tokens.");
+                }
+            } else {
+                logger.info("Error occurred while requesting authorization code from OP.");
+                AuthenticationError.sendAuthenticationError(response);
+            }
+
+        return null;
+
+    }
+
+}

--- a/oidc-handler/core/src/main/java/org/apache/sling/oidchandler/core/user/UserManagerImpl.java
+++ b/oidc-handler/core/src/main/java/org/apache/sling/oidchandler/core/user/UserManagerImpl.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.sling.oidchandler.core.user;
+
+import org.apache.jackrabbit.api.JackrabbitSession;
+import org.apache.jackrabbit.api.security.user.*;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.jcr.Credentials;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.jcr.SimpleCredentials;
+import org.apache.sling.jcr.api.SlingRepository;
+
+public class UserManagerImpl {
+
+    private final Logger logger = LoggerFactory.getLogger(UserManagerImpl.class);
+    private Session adminSession;
+
+    private static SlingRepository getSlingRepository() {
+        BundleContext bundleContext = FrameworkUtil.getBundle(SlingRepository.class).getBundleContext();
+        return (SlingRepository)bundleContext.getService(bundleContext
+                .getServiceReference(SlingRepository.class.getName()));
+    }
+
+    public boolean createUser(String name, String password) throws RepositoryException {
+        logger.info("creating user with id '{}'", name);
+
+        // usual entry point into the Jackrabbit API
+        Session session = getSession();
+        UserManager userManager = getUserManager(session);
+        String usersPath = "/" + name;
+        User user = userManager.createUser(name, password);
+        user.setProperty("homeFolder", session.getValueFactory().createValue(usersPath));
+        session.save();
+
+        return true;
+    }
+
+    public User getUser(final Credentials credentials) {
+        if (credentials instanceof SimpleCredentials) {
+            final SimpleCredentials simpleCredentials = (SimpleCredentials) credentials;
+            final String userId = simpleCredentials.getUserID();
+            return getUser(userId);
+        }
+        return null;
+    }
+
+    protected User getUser(final String userId) {
+        logger.info("getting user with id '{}'", userId);
+        try {
+            Session session = getSession();
+            UserManager userManager = getUserManager(session);
+            Authorizable authorizable = userManager.getAuthorizable(userId);
+            if (authorizable != null) {
+                if (authorizable instanceof User) {
+                    User user = (User) authorizable;
+                    logger.debug("user for id '{}' found", userId);
+                    return user;
+                } else {
+                    logger.debug("found authorizable with id '{}' is not an user", authorizable.getID());
+                }
+            }
+        } catch (Exception e) {
+            logger.error(e.getMessage(), e);
+        }
+        return null;
+    }
+
+    private synchronized Session getSession() throws RepositoryException {
+        if (adminSession == null || !adminSession.isLive()) {
+            adminSession = getSlingRepository().loginAdministrative(null);
+        }
+        return adminSession;
+    }
+
+    private UserManager getUserManager(Session session) throws RepositoryException {
+        if (session instanceof JackrabbitSession) {
+            JackrabbitSession jackrabbitSession = (JackrabbitSession) session;
+            return jackrabbitSession.getUserManager();
+        } else {
+            logger.error("Cannot get UserManager from session: not a Jackrabbit session");
+            return null;
+        }
+    }
+
+}

--- a/oidc-handler/core/src/main/java/org/apache/sling/oidchandler/core/util/OPConstant.java
+++ b/oidc-handler/core/src/main/java/org/apache/sling/oidchandler/core/util/OPConstant.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.sling.oidchandler.core.util;
+
+public class OPConstant {
+
+    //Google Details
+    public static final String google_issuer_url = "https://accounts.google.com";
+    public static final String google_authorization_endpoint = "https://accounts.google.com/o/oauth2/auth";
+    public static final String google_token_endpoint = "https://www.googleapis.com/oauth2/v4/token";
+    public static final String google_userinfo_endpoint = "https://www.googleapis.com/oauth2/v3/userinfo";
+    public static final String google_revocation_endpoint = "https://accounts.google.com/o/oauth2/revoke";
+    public static final String google_jwks_uri = "https://www.googleapis.com/oauth2/v3/certs";
+
+    //Relying Party Details
+    public static final String oidc_callback_url = "http://localhost:8080/";
+    public static final String oidc_scope = "openid email profile";
+}

--- a/oidc-handler/pom.xml
+++ b/oidc-handler/pom.xml
@@ -1,11 +1,212 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.apache.sling</groupId>
-    <artifactId>org.apache.sling.oidchandler</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <artifactId>org.apache.sling.auth.oidc</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <name>org.apache.sling.oidchandler</name>
+
+    <parent>
+        <groupId>org.apache.sling</groupId>
+        <artifactId>sling</artifactId>
+        <version>33</version>
+        <relativePath/>
+    </parent>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.6</version>
+                <configuration>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
+
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.engine</artifactId>
+            <version>2.4.6</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+            <version>2.5</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.core</artifactId>
+            <version>6.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.api</artifactId>
+            <version>2.9.0</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.6</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>osgi.annotation</artifactId>
+            <version>6.0.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.service.component.annotations</artifactId>
+            <version>1.3.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.service.metatype.annotations</artifactId>
+            <version>1.3.0</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- tagsoup -->
+        <dependency>
+            <groupId>org.ccil.cowan.tagsoup</groupId>
+            <artifactId>tagsoup</artifactId>
+            <version>1.2.1</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/com.nimbusds/oauth2-oidc-sdk -->
+        <dependency>
+            <groupId>com.nimbusds</groupId>
+            <artifactId>oauth2-oidc-sdk</artifactId>
+            <version>5.62</version>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/com.nimbusds/nimbus-jose-jwt -->
+        <dependency>
+            <groupId>com.nimbusds</groupId>
+            <artifactId>nimbus-jose-jwt</artifactId>
+            <version>5.14</version>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/net.minidev/json-smart -->
+        <dependency>
+            <groupId>net.minidev</groupId>
+            <artifactId>json-smart</artifactId>
+            <version>2.3</version>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/com.nimbusds/lang-tag -->
+        <dependency>
+            <groupId>com.nimbusds</groupId>
+            <artifactId>lang-tag</artifactId>
+            <version>1.4.3</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.7</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.jcr.api</artifactId>
+            <version>2.4.0</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.jackrabbit</groupId>
+            <artifactId>jackrabbit-core</artifactId>
+            <version>2.17.3</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.jackrabbit</groupId>
+            <artifactId>jackrabbit-jcr-commons</artifactId>
+            <version>2.17.3</version>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.jcr</groupId>
+            <artifactId>jcr</artifactId>
+            <version>2.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.jackrabbit</groupId>
+            <artifactId>jackrabbit-api</artifactId>
+            <version>2.17.3</version>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.apache.sling/org.apache.sling.jcr.jackrabbit.usermanager -->
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.jcr.jackrabbit.usermanager</artifactId>
+            <version>2.2.6</version>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.apache.sling/org.apache.sling.auth.core -->
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.auth.core</artifactId>
+            <version>1.4.2</version>
+            <scope>provided</scope>
+        </dependency>
+
+    </dependencies>
 
 </project>


### PR DESCRIPTION
### **GSoC 2018 — OpenID Connect Relying Party Implementation for Apache Sling**

**OpenID Connect Introduction**

OpenID Connect(OIDC) is an authentication protocol. There are three participants that engage in OIDC message passing.    

- End user — End user is same as the resource owner who is requested for identity information.
- Relying Party(RP) — Relying Party is same as the OAuth2.0 client requiring End-User authentication and claims from an OpenID Provider.
- OpenID Provider(OP) — OpenID provider is same as the OAuth2.0 Authorization Server that is capable of authenticating the End-User and providing claims to a Relying Party about the Authentication event and the End-User.

The below diagram illustrates the high level request passing that happens in OIDC.

![open-id-connect](https://user-images.githubusercontent.com/17598367/44026638-528b8ed0-9f11-11e8-98d4-cf5701d8f151.png)

First the RP will send an authentication request for the OpenID Provider(OP). Then OP will redirect the end-user to an authentication page. Then OP will authenticate the end-user and will obtain authorization. OP will send an access token and ID token to the RP. RP can send back the access token to OP’s userinfo endpoint and request user claims. Then OP can provide user claims back to RP.

**Project Description**

The purpose of this project is to implement OpenID Connect Relying party handler for Apache Sling. Following were identified as end deliverables for the proposed project.

- Send an authentication request for a OP.
- Request Access Token and ID Token from OP.
- Validate ID Token using nonce value.
- Get authenticated users.
- Save user claims.

Below diagram shows the proposed approach of the implementation.
![project proposal - apache sling 1](https://user-images.githubusercontent.com/17598367/44026677-72f025b4-9f11-11e8-910b-ef14d8c6e750.jpg)
**TODOs**
- Implementing test cases.
- Cookie value implementation.

**For more project information :**
- [https://cwiki.apache.org/confluence/display/SLING/GSOC+2018+-+Provide+an+OpenID+Connect+Authentication+Handler](url)
- [https://issues.apache.org/jira/browse/SLING-2759](url)







