### PR TITLE
SLING-8570 - Extract a generic Content Parser API from org.apache.sling.jcr.contentparser with pluggable implementations

### DIFF
--- a/contentparser/org-apache-sling-contentparser-api/README.md
+++ b/contentparser/org-apache-sling-contentparser-api/README.md
@@ -8,8 +8,7 @@ continuation of the one provided by the [Apache Sling JCR Content Parser](https:
 1. the API is now available in the `org.apache.sling.contentparser.api` package;
 2. there is no replacement for the `org.apache.sling.jcr.contentparser.ContentParserFactory`; to obtain a `ContentParser`, given that 
 they are exposed as OSGi services, one has to filter on the `ContentParser.SERVICE_PROPERTY_CONTENT_TYPE` service registration property,
-to select the appropriate file format (see `ContentParser.JSON_CONTENT_TYPE`, `ContentParser.XML_CONTENT_TYPE` and
-`ContentParser.JCR_XML_CONTENT_TYPE`);
+to select the appropriate file format;
 3. as a consequence of 2., the `ParserOptions` are now passed directly to the `ContentParser#parse` method.
 
 Implementations of the API are made available from separate bundles:

--- a/contentparser/org-apache-sling-contentparser-api/src/main/java/org/apache/sling/contentparser/api/ContentParser.java
+++ b/contentparser/org-apache-sling-contentparser-api/src/main/java/org/apache/sling/contentparser/api/ContentParser.java
@@ -31,37 +31,23 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface ContentParser {
 
-    /**
-     * JSON content descriptor file.
-     *
-     * @see <a href="https://sling.apache.org/documentation/bundles/content-loading-jcr-contentloader.html#json-descriptor-files">JCR
-     * ContentLoader JSON descriptor files</a>
-     */
-    String JSON_CONTENT_TYPE = "json";
 
     /**
-     * XML content descriptor file.
+     * OSGi service registration property indicating the content type this {@code ContentParser} supports. The simplest way to retrieve a
+     * {@code ContentParser} for a certain content type is to apply a filter on the service reference:
      *
-     * @see <a href="https://sling.apache.org/documentation/bundles/content-loading-jcr-contentloader.html#xml-descriptor-files">JCR
-     * ContentLoader XML descriptor files</a>
-     */
-    String XML_CONTENT_TYPE = "xml";
-
-    /**
-     * JCR XML content (FileVault XML),aAlso known as extended document view XML. Extends the regular document view as specified by JCR 2.0
-     * with specifics like multi-value and type information.
+     * <pre>
+     *    {@literal @}Reference(target = "(" + ContentParser.SERVICE_PROPERTY_CONTENT_TYPE + "=" + _value_ + ")")
+     *     private ContentParser parser;
+     * </pre>
      *
-     * @see <a href="https://docs.adobe.com/content/docs/en/spec/jcr/2.0/7_Export.html#7.3%20Document%20View">JCR 2.0, 7.3 Document View</a>
-     * @see <a href="http://jackrabbit.apache.org/filevault/">Jackrabbit FileVault</a>
-     */
-    String JCR_XML_CONTENT_TYPE = "jcr.xml";
-
-    /**
-     * OSGi service registration property indicating the content type this {@code ContentParser} supports.
+     * If multiple services are registered for the same content type, the above code snippet will provide you with the service
+     * implementation with the highest ranking. However, if a certain implementation is needed, an additional filter can be added:
      *
-     * @see #JSON_CONTENT_TYPE
-     * @see #XML_CONTENT_TYPE
-     * @see #JCR_XML_CONTENT_TYPE
+     * <pre>
+     *     {@literal @}Reference(target = "(&amp;(" + ContentParser.SERVICE_PROPERTY_CONTENT_TYPE + "=" + _value_ + ")(component.name=" + _class_name_ + "))")
+     *      private ContentParser parser;
+     * </pre>
      */
     String SERVICE_PROPERTY_CONTENT_TYPE = "org.apache.sling.contentparser.content_type";
 

--- a/contentparser/org-apache-sling-contentparser-api/src/main/java/org/apache/sling/contentparser/api/ParserOptions.java
+++ b/contentparser/org-apache-sling-contentparser-api/src/main/java/org/apache/sling/contentparser/api/ParserOptions.java
@@ -20,17 +20,17 @@ package org.apache.sling.contentparser.api;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Set;
 
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
- * Options for content parsers.
+ * Generic options for content parsers. Parser implementations can extend this class to provide additional options, valid only in the
+ * context of those implementations.
  */
 @ProviderType
-public final class ParserOptions {
+public class ParserOptions {
 
     /**
      * Default primary type.
@@ -57,18 +57,13 @@ public final class ParserOptions {
             "security:principals"
     )));
 
-    /**
-     * List of JSON parser features activated by default.
-     */
-    public static final EnumSet<JsonParserFeature> DEFAULT_JSON_PARSER_FEATURES
-            = EnumSet.of(JsonParserFeature.COMMENTS);
+
 
     private String defaultPrimaryType = DEFAULT_PRIMARY_TYPE;
     private boolean detectCalendarValues;
     private Set<String> ignorePropertyNames = Collections.emptySet();
     private Set<String> ignoreResourceNames = DEFAULT_IGNORE_RESOURCE_NAMES;
     private Set<String> removePropertyNamePrefixes = DEFAULT_REMOVE_PROPERTY_NAME_PREFIXES;
-    private EnumSet<JsonParserFeature> jsonParserFeatures = DEFAULT_JSON_PARSER_FEATURES;
 
     /**
      * Default "jcr:primaryType" property for resources that have no explicit value for this value.
@@ -148,24 +143,6 @@ public final class ParserOptions {
         return removePropertyNamePrefixes;
     }
 
-    /**
-     * Set set of features the JSON parser should apply when parsing files.
-     *
-     * @param value JSON parser features
-     * @return this
-     */
-    public ParserOptions jsonParserFeatures(EnumSet<JsonParserFeature> value) {
-        this.jsonParserFeatures = value;
-        return this;
-    }
 
-    public ParserOptions jsonParserFeatures(JsonParserFeature... value) {
-        this.jsonParserFeatures = EnumSet.copyOf(Arrays.asList(value));
-        return this;
-    }
-
-    public EnumSet<JsonParserFeature> getJsonParserFeatures() {
-        return jsonParserFeatures;
-    }
 
 }

--- a/contentparser/org-apache-sling-contentparser-api/src/main/java/org/apache/sling/contentparser/api/package-info.java
+++ b/contentparser/org-apache-sling-contentparser-api/src/main/java/org/apache/sling/contentparser/api/package-info.java
@@ -16,7 +16,7 @@
  ~ specific language governing permissions and limitations
  ~ under the License.
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
-@Version("1.0.0")
+@Version("2.0.0")
 package org.apache.sling.contentparser.api;
 
 import org.osgi.annotation.versioning.Version;

--- a/contentparser/org-apache-sling-contentparser-json/README.md
+++ b/contentparser/org-apache-sling-contentparser-json/README.md
@@ -9,6 +9,6 @@ To obtain a reference to the JSON content parser just filter on the `ContentPars
 property:
 
 ```java
-    @Reference(target = "(" + ContentParser.SERVICE_PROPERTY_CONTENT_TYPE + "=" + ContentParser.JSON_CONTENT_TYPE + ")")
+    @Reference(target = "(" + ContentParser.SERVICE_PROPERTY_CONTENT_TYPE + "=json)")
     private ContentParser jsonParser;
 ``` 

--- a/contentparser/org-apache-sling-contentparser-json/pom.xml
+++ b/contentparser/org-apache-sling-contentparser-json/pom.xml
@@ -79,6 +79,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.annotation.versioning</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.contentparser.testutils</artifactId>
             <version>0.9.0-SNAPSHOT</version>

--- a/contentparser/org-apache-sling-contentparser-json/src/main/java/org/apache/sling/contentparser/json/JSONParserFeature.java
+++ b/contentparser/org-apache-sling-contentparser-json/src/main/java/org/apache/sling/contentparser/json/JSONParserFeature.java
@@ -16,12 +16,12 @@
  ~ specific language governing permissions and limitations
  ~ under the License.
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
-package org.apache.sling.contentparser.api;
+package org.apache.sling.contentparser.json;
 
 /**
  * Feature flags for parsing JSON files.
  */
-public enum JsonParserFeature {
+public enum JSONParserFeature {
 
     /**
      * Support comments (&#47;* ... *&#47;) in JSON files.

--- a/contentparser/org-apache-sling-contentparser-json/src/main/java/org/apache/sling/contentparser/json/JSONParserOptions.java
+++ b/contentparser/org-apache-sling-contentparser-json/src/main/java/org/apache/sling/contentparser/json/JSONParserOptions.java
@@ -1,0 +1,57 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Licensed to the Apache Software Foundation (ASF) under one
+ ~ or more contributor license agreements.  See the NOTICE file
+ ~ distributed with this work for additional information
+ ~ regarding copyright ownership.  The ASF licenses this file
+ ~ to you under the Apache License, Version 2.0 (the
+ ~ "License"); you may not use this file except in compliance
+ ~ with the License.  You may obtain a copy of the License at
+ ~
+ ~   http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied.  See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package org.apache.sling.contentparser.json;
+
+import java.util.Arrays;
+import java.util.EnumSet;
+
+import org.apache.sling.contentparser.api.ParserOptions;
+import org.osgi.annotation.versioning.ConsumerType;
+
+@ConsumerType
+public final class JSONParserOptions extends ParserOptions {
+
+    /**
+     * List of JSON parser features activated by default.
+     */
+    public static final EnumSet<JSONParserFeature> DEFAULT_JSON_PARSER_FEATURES
+            = EnumSet.of(JSONParserFeature.COMMENTS);
+
+    private EnumSet<JSONParserFeature> features = DEFAULT_JSON_PARSER_FEATURES;
+
+    /**
+     * Set set of features the JSON parser should apply when parsing files.
+     *
+     * @param value JSON parser features
+     * @return this
+     */
+    public JSONParserOptions withFeatures(EnumSet<JSONParserFeature> value) {
+        this.features = value;
+        return this;
+    }
+
+    public JSONParserOptions withFeatures(JSONParserFeature... value) {
+        this.features = EnumSet.copyOf(Arrays.asList(value));
+        return this;
+    }
+
+    public EnumSet<JSONParserFeature> getFeatures() {
+        return features;
+    }
+}

--- a/contentparser/org-apache-sling-contentparser-json/src/main/java/org/apache/sling/contentparser/json/JSONParserOptions.java
+++ b/contentparser/org-apache-sling-contentparser-json/src/main/java/org/apache/sling/contentparser/json/JSONParserOptions.java
@@ -24,6 +24,10 @@ import java.util.EnumSet;
 import org.apache.sling.contentparser.api.ParserOptions;
 import org.osgi.annotation.versioning.ConsumerType;
 
+/**
+ * Defines specific JSON parser options which can be used with the JSON {@link org.apache.sling.contentparser.api.ContentParser}
+ * implementations provided by this bundle.
+ */
 @ConsumerType
 public final class JSONParserOptions extends ParserOptions {
 
@@ -36,22 +40,34 @@ public final class JSONParserOptions extends ParserOptions {
     private EnumSet<JSONParserFeature> features = DEFAULT_JSON_PARSER_FEATURES;
 
     /**
-     * Set set of features the JSON parser should apply when parsing files.
+     * Set the features the JSON parser should apply when parsing files.
      *
      * @param value JSON parser features
      * @return this
      */
     public JSONParserOptions withFeatures(EnumSet<JSONParserFeature> value) {
-        this.features = value;
+        this.features = EnumSet.copyOf(value);
         return this;
     }
 
+    /**
+     * Set the features the JSON parser should apply when parsing files.
+     *
+     * @param value JSON parser features
+     * @return this
+     */
     public JSONParserOptions withFeatures(JSONParserFeature... value) {
         this.features = EnumSet.copyOf(Arrays.asList(value));
         return this;
     }
 
+    /**
+     * Returns a copy of the features encapsulated by this instance. For modifying the set of features please use the {@code withFeatures}
+     * fluid methods.
+     *
+     * @return the features the JSON parser should apply when parsing files
+     */
     public EnumSet<JSONParserFeature> getFeatures() {
-        return features;
+        return EnumSet.copyOf(features);
     }
 }

--- a/contentparser/org-apache-sling-contentparser-json/src/main/java/org/apache/sling/contentparser/json/internal/JSONTicksConverter.java
+++ b/contentparser/org-apache-sling-contentparser-json/src/main/java/org/apache/sling/contentparser/json/internal/JSONTicksConverter.java
@@ -29,9 +29,9 @@ package org.apache.sling.contentparser.json.internal;
  *     After the conversion they are always escaped.</li>
  * </ul>
  */
-final class JsonTicksConverter {
+final class JSONTicksConverter {
     
-    private JsonTicksConverter() {
+    private JSONTicksConverter() {
         // static methods only
     }
     

--- a/contentparser/org-apache-sling-contentparser-json/src/main/java/org/apache/sling/contentparser/json/package-info.java
+++ b/contentparser/org-apache-sling-contentparser-json/src/main/java/org/apache/sling/contentparser/json/package-info.java
@@ -16,7 +16,7 @@
  ~ specific language governing permissions and limitations
  ~ under the License.
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
-@Version("1.0.0")
+@Version("2.0.0")
 package org.apache.sling.contentparser.json;
 
 import org.osgi.annotation.versioning.Version;

--- a/contentparser/org-apache-sling-contentparser-json/src/main/java/org/apache/sling/contentparser/json/package-info.java
+++ b/contentparser/org-apache-sling-contentparser-json/src/main/java/org/apache/sling/contentparser/json/package-info.java
@@ -1,0 +1,22 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Licensed to the Apache Software Foundation (ASF) under one
+ ~ or more contributor license agreements.  See the NOTICE file
+ ~ distributed with this work for additional information
+ ~ regarding copyright ownership.  The ASF licenses this file
+ ~ to you under the Apache License, Version 2.0 (the
+ ~ "License"); you may not use this file except in compliance
+ ~ with the License.  You may obtain a copy of the License at
+ ~
+ ~   http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied.  See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+@Version("1.0.0")
+package org.apache.sling.contentparser.json;
+
+import org.osgi.annotation.versioning.Version;

--- a/contentparser/org-apache-sling-contentparser-json/src/test/java/org/apache/sling/contentparser/json/internal/JSONContentParserTest.java
+++ b/contentparser/org-apache-sling-contentparser-json/src/test/java/org/apache/sling/contentparser/json/internal/JSONContentParserTest.java
@@ -16,53 +16,55 @@
  ~ specific language governing permissions and limitations
  ~ under the License.
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
-package org.apache.sling.contentparser.xml.internal;
+package org.apache.sling.contentparser.json.internal;
 
 import java.io.File;
 import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.TimeZone;
 
 import org.apache.sling.contentparser.api.ContentParser;
 import org.apache.sling.contentparser.api.ParseException;
-import org.apache.sling.contentparser.api.ParserOptions;
+import org.apache.sling.contentparser.json.JSONParserFeature;
+import org.apache.sling.contentparser.json.JSONParserOptions;
 import org.apache.sling.contentparser.testutils.TestUtils;
 import org.apache.sling.contentparser.testutils.mapsupport.ContentElement;
 import org.junit.Before;
 import org.junit.Test;
 
+import static junit.framework.TestCase.assertNull;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 
-public class XmlContentParserTest {
+public class JSONContentParserTest {
 
     private File file;
-    private ContentParser underTest;
+    private ContentParser contentParser;
 
     @Before
     public void setUp() {
-        file = new File("src/test/resources/content-test/content.xml");
-        underTest = new XmlContentParser();
+        file = new File("src/test/resources/content-test/content.json");
+        contentParser = new JSONContentParser();
     }
 
     @Test
     public void testPageJcrPrimaryType() throws Exception {
-        ContentElement content = TestUtils.parse(underTest, file);
+        ContentElement content = TestUtils.parse(contentParser, new JSONParserOptions(), file);
 
         assertEquals("app:Page", content.getProperties().get("jcr:primaryType"));
     }
 
     @Test
     public void testDataTypes() throws Exception {
-        ContentElement content = TestUtils.parse(underTest, file);
+        ContentElement content = TestUtils.parse(contentParser, new JSONParserOptions(), file);
         ContentElement child = content.getChild("toolbar/profiles/jcr:content");
-        assertNotNull("Expected child at path toolbar/profiles/jcr:content", child);
+        assertNotNull("Expected child at toolbar/profiles/jcr:content", child);
         Map<String, Object> props = child.getProperties();
         assertEquals(true, props.get("hideInNav"));
 
@@ -77,7 +79,7 @@ public class XmlContentParserTest {
 
     @Test
     public void testContentProperties() throws Exception {
-        ContentElement content = TestUtils.parse(underTest, file);
+        ContentElement content = TestUtils.parse(contentParser, new JSONParserOptions(), file);
         ContentElement child = content.getChild("jcr:content/header");
         assertNotNull("Expected child at jcr:content/header", child);
         Map<String, Object> props = child.getProperties();
@@ -86,7 +88,7 @@ public class XmlContentParserTest {
 
     @Test
     public void testCalendar() throws Exception {
-        ContentElement content = TestUtils.parse(underTest, new ParserOptions().detectCalendarValues(true), file);
+        ContentElement content = TestUtils.parse(contentParser, new JSONParserOptions().detectCalendarValues(true), file);
         ContentElement child = content.getChild("jcr:content");
         assertNotNull("Expected child at jcr:content", child);
         Map<String, Object> props = child.getProperties();
@@ -106,57 +108,74 @@ public class XmlContentParserTest {
     }
 
     @Test
-    public void testUTF8Chars() throws Exception {
-        ContentElement content = TestUtils.parse(underTest, file);
+    public void testIso8601Calendar() throws Exception {
+        ContentElement content = TestUtils.parse(contentParser, new JSONParserOptions().detectCalendarValues(true), file);
         ContentElement child = content.getChild("jcr:content");
         assertNotNull("Expected child at jcr:content", child);
         Map<String, Object> props = child.getProperties();
+
+        Calendar calendar = (Calendar) props.get("dateISO8601String");
+        assertNotNull(calendar);
+
+        assertEquals(2014, calendar.get(Calendar.YEAR));
+        assertEquals(4, calendar.get(Calendar.MONTH) + 1);
+        assertEquals(22, calendar.get(Calendar.DAY_OF_MONTH));
+
+        assertEquals(15, calendar.get(Calendar.HOUR_OF_DAY));
+        assertEquals(11, calendar.get(Calendar.MINUTE));
+        assertEquals(24, calendar.get(Calendar.SECOND));
+    }
+
+    @Test
+    public void testUTF8Chars() throws Exception {
+        ContentElement content = TestUtils.parse(contentParser, new JSONParserOptions(), file);
+        ContentElement child = content.getChild("jcr:content");
+        assertNotNull("Expected child at jcr:content", child);
+        Map<String, Object> props = child.getProperties();
+
         assertEquals("äöüß€", props.get("utf8Property"));
     }
 
     @Test(expected = ParseException.class)
     public void testParseInvalidJson() throws Exception {
         file = new File("src/test/resources/invalid-test/invalid.json");
-
-        ContentElement content = TestUtils.parse(underTest, file);
+        ContentElement content = TestUtils.parse(contentParser, file);
         assertNull(content);
     }
 
     @Test(expected = ParseException.class)
     public void testParseInvalidJsonWithObjectList() throws Exception {
         file = new File("src/test/resources/invalid-test/contentWithObjectList.json");
-
-        ContentElement content = TestUtils.parse(underTest, file);
+        ContentElement content = TestUtils.parse(contentParser, file);
         assertNull(content);
     }
 
     @Test
     public void testIgnoreResourcesProperties() throws Exception {
-        ContentElement content = TestUtils.parse(underTest,
-                new ParserOptions().ignoreResourceNames(Collections.unmodifiableSet(new HashSet<>(Arrays.asList("header", "newslist"))))
+        ContentElement content = TestUtils.parse(
+                contentParser,
+                new JSONParserOptions().ignoreResourceNames(Collections
+                        .unmodifiableSet(new HashSet<>(Arrays.asList("header", "newslist", "security:acl", "security:principals"))))
                         .ignorePropertyNames(Collections.unmodifiableSet(new HashSet<>(Arrays.asList("jcr:title")))), file);
         ContentElement child = content.getChild("jcr:content");
         assertNotNull("Expected child at jcr:content", child);
-        Map<String, Object> props = child.getProperties();
-
-        assertEquals("Sample Homepage", props.get("pageTitle"));
-        assertEquals("abc", props.get("refpro1"));
-        assertEquals("def", props.get("pathprop1"));
-        assertNull(props.get("jcr:title"));
+        assertEquals("Sample Homepage", child.getProperties().get("pageTitle"));
+        assertNull(child.getProperties().get("jcr:title"));
 
         assertNull(child.getChildren().get("header"));
         assertNull(child.getChildren().get("newslist"));
         assertNotNull(child.getChildren().get("lead"));
+
+        assertEquals("abc", child.getProperties().get("refpro1"));
+        assertEquals("def", child.getProperties().get("pathprop1"));
     }
 
     @Test
     public void testGetChild() throws Exception {
-
-        ContentElement content = TestUtils.parse(underTest, file);
+        ContentElement content = TestUtils.parse(contentParser, new JSONParserOptions(), file);
         assertNull(content.getName());
-
         ContentElement deepChild = content.getChild("jcr:content/par/image/file/jcr:content");
-        assertNotNull("Expected a child at path jcr:content/par/image/file/jcr:content", deepChild);
+        assertNotNull("Expected child at jcr:content/par/image/file/jcr:content", deepChild);
         assertEquals("jcr:content", deepChild.getName());
         assertEquals("nt:resource", deepChild.getProperties().get("jcr:primaryType"));
 
@@ -165,6 +184,11 @@ public class XmlContentParserTest {
 
         invalidChild = content.getChild("/jcr:content");
         assertNull(invalidChild);
+    }
+
+    @Test(expected = ParseException.class)
+    public void testFailsWithoutCommentsEnabled() throws Exception {
+        TestUtils.parse(contentParser, new JSONParserOptions().withFeatures(EnumSet.noneOf(JSONParserFeature.class)), file);
     }
 
 }

--- a/contentparser/org-apache-sling-contentparser-xml-jcr/README.md
+++ b/contentparser/org-apache-sling-contentparser-xml-jcr/README.md
@@ -5,7 +5,7 @@ This module is part of the [Apache Sling](https://sling.apache.org) project.
 The Apache Sling Content Parser for JackRabbit FileVault XML provides support for parsing XML files into Apache Sling resource trees, by implementing the 
 API provided by the [`org.apache.sling.contentparser.api`](https://github.com/apache/sling-whiteboard/tree/master/contentparser/org-apache-sling-contentparser-api) bundle.
 
-To obtain a reference to the JackRabbit FileVault XMLL content parser just filter on the `ContentParser.SERVICE_PROPERTY_CONTENT_TYPE` service registration 
+To obtain a reference to the JackRabbit FileVault XML content parser just filter on the `ContentParser.SERVICE_PROPERTY_CONTENT_TYPE` service registration 
 property:
 
 ```java

--- a/contentparser/org-apache-sling-contentparser-xml-jcr/README.md
+++ b/contentparser/org-apache-sling-contentparser-xml-jcr/README.md
@@ -9,6 +9,6 @@ To obtain a reference to the JackRabbit FileVault XMLL content parser just filte
 property:
 
 ```java
-    @Reference(target = "(" + ContentParser.SERVICE_PROPERTY_CONTENT_TYPE + "=" + ContentParser.JCR_XML_CONTENT_TYPE + ")")
+    @Reference(target = "(" + ContentParser.SERVICE_PROPERTY_CONTENT_TYPE + "=jcr-xml)")
     private ContentParser jcrXmlParser;
 ``` 

--- a/contentparser/org-apache-sling-contentparser-xml-jcr/src/main/java/org/apache/sling/contentparser/xml/jcr/internal/JCRXMLContentParser.java
+++ b/contentparser/org-apache-sling-contentparser-xml-jcr/src/main/java/org/apache/sling/contentparser/xml/jcr/internal/JCRXMLContentParser.java
@@ -46,14 +46,14 @@ import org.xml.sax.helpers.DefaultHandler;
 @Component(
         service = ContentParser.class,
         property = {
-                ContentParser.SERVICE_PROPERTY_CONTENT_TYPE + "=" + ContentParser.JCR_XML_CONTENT_TYPE
+                ContentParser.SERVICE_PROPERTY_CONTENT_TYPE + "=jcr-xml"
         }
 )
-public final class JcrXmlContentParser implements ContentParser {
+public final class JCRXMLContentParser implements ContentParser {
 
     private final SAXParserFactory saxParserFactory;
 
-    public JcrXmlContentParser() {
+    public JCRXMLContentParser() {
         saxParserFactory = SAXParserFactory.newInstance();
         saxParserFactory.setNamespaceAware(true);
     }

--- a/contentparser/org-apache-sling-contentparser-xml-jcr/src/test/java/org/apache/sling/contentparser/xml/jcr/internal/JCRXMLContentParserTest.java
+++ b/contentparser/org-apache-sling-contentparser-xml-jcr/src/test/java/org/apache/sling/contentparser/xml/jcr/internal/JCRXMLContentParserTest.java
@@ -41,7 +41,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
-public class JcrXmlContentParserTest {
+public class JCRXMLContentParserTest {
 
     private File file;
     private ContentParser underTest;
@@ -49,7 +49,7 @@ public class JcrXmlContentParserTest {
     @Before
     public void setUp() {
         file = new File("src/test/resources/content-test/content.jcr.xml");
-        underTest = new JcrXmlContentParser();
+        underTest = new JCRXMLContentParser();
     }
 
     @Test
@@ -96,8 +96,8 @@ public class JcrXmlContentParserTest {
 
     @Test
     public void testDecodeName() {
-        assertEquals("jcr:title", JcrXmlContentParser.decodeName("jcr:" + ISO9075.encode("title")));
-        assertEquals("sling:123", JcrXmlContentParser.decodeName("sling:" + ISO9075.encode("123")));
+        assertEquals("jcr:title", JCRXMLContentParser.decodeName("jcr:" + ISO9075.encode("title")));
+        assertEquals("sling:123", JCRXMLContentParser.decodeName("sling:" + ISO9075.encode("123")));
     }
 
     @Test

--- a/contentparser/org-apache-sling-contentparser-xml/README.md
+++ b/contentparser/org-apache-sling-contentparser-xml/README.md
@@ -9,6 +9,6 @@ To obtain a reference to the XML content parser just filter on the `ContentParse
 property:
 
 ```java
-    @Reference(target = "(" + ContentParser.SERVICE_PROPERTY_CONTENT_TYPE + "=" + ContentParser.XML_CONTENT_TYPE + ")")
+    @Reference(target = "(" + ContentParser.SERVICE_PROPERTY_CONTENT_TYPE + "=xml)")
     private ContentParser xmlParser;
 ``` 

--- a/contentparser/org-apache-sling-contentparser-xml/src/main/java/org/apache/sling/contentparser/xml/internal/XMLContentParser.java
+++ b/contentparser/org-apache-sling-contentparser-xml/src/main/java/org/apache/sling/contentparser/xml/internal/XMLContentParser.java
@@ -49,15 +49,15 @@ import org.xml.sax.SAXException;
  */
 @Component(
         property = {
-                ContentParser.SERVICE_PROPERTY_CONTENT_TYPE + "=" + ContentParser.XML_CONTENT_TYPE
+                ContentParser.SERVICE_PROPERTY_CONTENT_TYPE + "=xml"
         }
 )
-public final class XmlContentParser implements ContentParser {
+public final class XMLContentParser implements ContentParser {
 
     private static final String JCR_PRIMARY_TYPE = "jcr:primaryType";
     private final DocumentBuilderFactory documentBuilderFactory;
 
-    public XmlContentParser() {
+    public XMLContentParser() {
         documentBuilderFactory = DocumentBuilderFactory.newInstance();
     }
 

--- a/contentparser/org-apache-sling-contentparser-xml/src/test/java/org/apache/sling/contentparser/xml/internal/XMLContentParserTest.java
+++ b/contentparser/org-apache-sling-contentparser-xml/src/test/java/org/apache/sling/contentparser/xml/internal/XMLContentParserTest.java
@@ -16,20 +16,18 @@
  ~ specific language governing permissions and limitations
  ~ under the License.
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
-package org.apache.sling.contentparser.json.internal;
+package org.apache.sling.contentparser.xml.internal;
 
 import java.io.File;
 import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
-import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.TimeZone;
 
 import org.apache.sling.contentparser.api.ContentParser;
-import org.apache.sling.contentparser.api.JsonParserFeature;
 import org.apache.sling.contentparser.api.ParseException;
 import org.apache.sling.contentparser.api.ParserOptions;
 import org.apache.sling.contentparser.testutils.TestUtils;
@@ -37,34 +35,34 @@ import org.apache.sling.contentparser.testutils.mapsupport.ContentElement;
 import org.junit.Before;
 import org.junit.Test;
 
-import static junit.framework.TestCase.assertNull;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
-public class JsonContentParserTest {
+public class XMLContentParserTest {
 
     private File file;
-    private ContentParser contentParser;
+    private ContentParser underTest;
 
     @Before
     public void setUp() {
-        file = new File("src/test/resources/content-test/content.json");
-        contentParser = new JsonContentParser();
+        file = new File("src/test/resources/content-test/content.xml");
+        underTest = new XMLContentParser();
     }
 
     @Test
     public void testPageJcrPrimaryType() throws Exception {
-        ContentElement content = TestUtils.parse(contentParser, file);
+        ContentElement content = TestUtils.parse(underTest, file);
 
         assertEquals("app:Page", content.getProperties().get("jcr:primaryType"));
     }
 
     @Test
     public void testDataTypes() throws Exception {
-        ContentElement content = TestUtils.parse(contentParser, file);
+        ContentElement content = TestUtils.parse(underTest, file);
         ContentElement child = content.getChild("toolbar/profiles/jcr:content");
-        assertNotNull("Expected child at toolbar/profiles/jcr:content", child);
+        assertNotNull("Expected child at path toolbar/profiles/jcr:content", child);
         Map<String, Object> props = child.getProperties();
         assertEquals(true, props.get("hideInNav"));
 
@@ -79,7 +77,7 @@ public class JsonContentParserTest {
 
     @Test
     public void testContentProperties() throws Exception {
-        ContentElement content = TestUtils.parse(contentParser, file);
+        ContentElement content = TestUtils.parse(underTest, file);
         ContentElement child = content.getChild("jcr:content/header");
         assertNotNull("Expected child at jcr:content/header", child);
         Map<String, Object> props = child.getProperties();
@@ -88,7 +86,7 @@ public class JsonContentParserTest {
 
     @Test
     public void testCalendar() throws Exception {
-        ContentElement content = TestUtils.parse(contentParser, new ParserOptions().detectCalendarValues(true), file);
+        ContentElement content = TestUtils.parse(underTest, new ParserOptions().detectCalendarValues(true), file);
         ContentElement child = content.getChild("jcr:content");
         assertNotNull("Expected child at jcr:content", child);
         Map<String, Object> props = child.getProperties();
@@ -108,74 +106,57 @@ public class JsonContentParserTest {
     }
 
     @Test
-    public void testIso8601Calendar() throws Exception {
-        ContentElement content = TestUtils.parse(contentParser, new ParserOptions().detectCalendarValues(true), file);
-        ContentElement child = content.getChild("jcr:content");
-        assertNotNull("Expected child at jcr:content", child);
-        Map<String, Object> props = child.getProperties();
-
-        Calendar calendar = (Calendar) props.get("dateISO8601String");
-        assertNotNull(calendar);
-
-        assertEquals(2014, calendar.get(Calendar.YEAR));
-        assertEquals(4, calendar.get(Calendar.MONTH) + 1);
-        assertEquals(22, calendar.get(Calendar.DAY_OF_MONTH));
-
-        assertEquals(15, calendar.get(Calendar.HOUR_OF_DAY));
-        assertEquals(11, calendar.get(Calendar.MINUTE));
-        assertEquals(24, calendar.get(Calendar.SECOND));
-    }
-
-    @Test
     public void testUTF8Chars() throws Exception {
-        ContentElement content = TestUtils.parse(contentParser, file);
+        ContentElement content = TestUtils.parse(underTest, file);
         ContentElement child = content.getChild("jcr:content");
         assertNotNull("Expected child at jcr:content", child);
         Map<String, Object> props = child.getProperties();
-
         assertEquals("äöüß€", props.get("utf8Property"));
     }
 
     @Test(expected = ParseException.class)
     public void testParseInvalidJson() throws Exception {
         file = new File("src/test/resources/invalid-test/invalid.json");
-        ContentElement content = TestUtils.parse(contentParser, file);
+
+        ContentElement content = TestUtils.parse(underTest, file);
         assertNull(content);
     }
 
     @Test(expected = ParseException.class)
     public void testParseInvalidJsonWithObjectList() throws Exception {
         file = new File("src/test/resources/invalid-test/contentWithObjectList.json");
-        ContentElement content = TestUtils.parse(contentParser, file);
+
+        ContentElement content = TestUtils.parse(underTest, file);
         assertNull(content);
     }
 
     @Test
     public void testIgnoreResourcesProperties() throws Exception {
-        ContentElement content = TestUtils.parse(
-                contentParser,
-                new ParserOptions().ignoreResourceNames(Collections
-                        .unmodifiableSet(new HashSet<>(Arrays.asList("header", "newslist", "security:acl", "security:principals"))))
+        ContentElement content = TestUtils.parse(underTest,
+                new ParserOptions().ignoreResourceNames(Collections.unmodifiableSet(new HashSet<>(Arrays.asList("header", "newslist"))))
                         .ignorePropertyNames(Collections.unmodifiableSet(new HashSet<>(Arrays.asList("jcr:title")))), file);
         ContentElement child = content.getChild("jcr:content");
         assertNotNull("Expected child at jcr:content", child);
-        assertEquals("Sample Homepage", child.getProperties().get("pageTitle"));
-        assertNull(child.getProperties().get("jcr:title"));
+        Map<String, Object> props = child.getProperties();
+
+        assertEquals("Sample Homepage", props.get("pageTitle"));
+        assertEquals("abc", props.get("refpro1"));
+        assertEquals("def", props.get("pathprop1"));
+        assertNull(props.get("jcr:title"));
 
         assertNull(child.getChildren().get("header"));
         assertNull(child.getChildren().get("newslist"));
         assertNotNull(child.getChildren().get("lead"));
-
-        assertEquals("abc", child.getProperties().get("refpro1"));
-        assertEquals("def", child.getProperties().get("pathprop1"));
     }
 
     @Test
     public void testGetChild() throws Exception {
-        ContentElement content = TestUtils.parse(contentParser, file);
+
+        ContentElement content = TestUtils.parse(underTest, file);
         assertNull(content.getName());
+
         ContentElement deepChild = content.getChild("jcr:content/par/image/file/jcr:content");
-        assertNotNull("Expected child at jcr:content/par/image/file/jcr:content", deepChild);
+        assertNotNull("Expected a child at path jcr:content/par/image/file/jcr:content", deepChild);
         assertEquals("jcr:content", deepChild.getName());
         assertEquals("nt:resource", deepChild.getProperties().get("jcr:primaryType"));
 
@@ -184,11 +165,6 @@ public class JsonContentParserTest {
 
         invalidChild = content.getChild("/jcr:content");
         assertNull(invalidChild);
-    }
-
-    @Test(expected = ParseException.class)
-    public void testFailsWithoutCommentsEnabled() throws Exception {
-        TestUtils.parse(contentParser, new ParserOptions().jsonParserFeatures(EnumSet.noneOf(JsonParserFeature.class)), file);
     }
 
 }


### PR DESCRIPTION
* completely decoupled the API from implementations - the ContentParser API
doesn't suggest any content types any more
* removed JSON specific parser options from the ParserOptions class
* made the ParserOptions class extendable