### PR TITLE
Fix output format to adhere to GraphQL spec

### DIFF
--- a/graphql-scripting/src/main/java/org/apache/sling/scripting/gql/engine/GraphQLScriptEngine.java
+++ b/graphql-scripting/src/main/java/org/apache/sling/scripting/gql/engine/GraphQLScriptEngine.java
@@ -75,10 +75,7 @@ public class GraphQLScriptEngine extends AbstractScriptEngine {
     }
 
     public static void sendJSON(PrintWriter out, ExecutionResult result) throws ScriptException {
-        if (!result.getErrors().isEmpty()) {
-            throw new ScriptException(("GraphQL query failed:" + result.getErrors()));
-        }
-        final Object data = result.getData();
+        final Object data = result.toSpecification();
         if (data == null) {
             throw new ScriptException("No data");
         }

--- a/graphql-scripting/src/test/java/org/apache/sling/scripting/graphql/it/BasicContentIT.java
+++ b/graphql-scripting/src/test/java/org/apache/sling/scripting/graphql/it/BasicContentIT.java
@@ -58,8 +58,8 @@ public class BasicContentIT extends GraphQLScriptingTestSupport {
     public void testJsonContent() throws Exception {
         final String path = "/graphql/one";
         final String json = getContent(path + ".json");
-        assertThat(json, hasJsonPath("$.currentResource"));
-        assertThat(json, hasJsonPath("$.currentResource.path", equalTo("/content/graphql/one")));
-        assertThat(json, hasJsonPath("$.currentResource.resourceType", equalTo("graphql/test/one")));
+        assertThat(json, hasJsonPath("$.data.currentResource"));
+        assertThat(json, hasJsonPath("$.data.currentResource.path", equalTo("/content/graphql/one")));
+        assertThat(json, hasJsonPath("$.data.currentResource.resourceType", equalTo("graphql/test/one")));
     }
 }

--- a/graphql-scripting/src/test/java/org/apache/sling/scripting/graphql/it/GraphQLServletIT.java
+++ b/graphql-scripting/src/test/java/org/apache/sling/scripting/graphql/it/GraphQLServletIT.java
@@ -72,25 +72,25 @@ public class GraphQLServletIT extends GraphQLScriptingTestSupport {
     @Test
     public void testGqlExt() throws Exception {
         final String json = getContent("/graphql/two.gql", "query", "{ currentResource { resourceType name } }");
-        assertThat(json, hasJsonPath("$.currentResource.resourceType", equalTo("graphql/test/two")));
-        assertThat(json, hasJsonPath("$.currentResource.name", equalTo("two")));
-        assertThat(json, hasNoJsonPath("$.currentResource.path"));
+        assertThat(json, hasJsonPath("$.data.currentResource.resourceType", equalTo("graphql/test/two")));
+        assertThat(json, hasJsonPath("$.data.currentResource.name", equalTo("two")));
+        assertThat(json, hasNoJsonPath("$.data.currentResource.path"));
     }
 
     @Test
     public void testGqlExtWithPost() throws Exception {
         final String json = getContentWithPost("/graphql/two.gql", "{ currentResource { resourceType name } }", null);
-        assertThat(json, hasJsonPath("$.currentResource.resourceType", equalTo("graphql/test/two")));
-        assertThat(json, hasJsonPath("$.currentResource.name", equalTo("two")));
-        assertThat(json, hasNoJsonPath("$.currentResource.path"));
+        assertThat(json, hasJsonPath("$.data.currentResource.resourceType", equalTo("graphql/test/two")));
+        assertThat(json, hasJsonPath("$.data.currentResource.name", equalTo("two")));
+        assertThat(json, hasNoJsonPath("$.data.currentResource.path"));
     }
 
     @Test
     public void testOtherExt() throws Exception {
         final String json = getContent("/graphql/two.testing.otherExt", "query", "{ currentResource { path name } }");
-        assertThat(json, hasJsonPath("$.currentResource.path", equalTo("/content/graphql/two")));
-        assertThat(json, hasJsonPath("$.currentResource.name", equalTo("two")));
-        assertThat(json, hasNoJsonPath("$.currentResource.resourceType"));
+        assertThat(json, hasJsonPath("$.data.currentResource.path", equalTo("/content/graphql/two")));
+        assertThat(json, hasJsonPath("$.data.currentResource.name", equalTo("two")));
+        assertThat(json, hasNoJsonPath("$.data.currentResource.resourceType"));
         executeRequest("GET", "/graphql/two.otherExt", null, 404);
     }
 


### PR DESCRIPTION
- Use "data" top-level container
- Correct error handling for query issues