### PR TITLE
Fixed build issue

### DIFF
--- a/saml-handler/README.md
+++ b/saml-handler/README.md
@@ -22,6 +22,12 @@ Synchronize user management based on the SAML2 Assertion and OSGi bundle configs
 `Helpers` hold static utility methods used with the OpenSAML V3 library  
 The parent `saml2` package has interface definitions, the bundle Activator
 
+### OSGI Requirements
+It is assumed the Sling environment provides certain bundles. The SAML2 bundle will not activate without:  
+* org.apache.jackrabbit.oak-auth-external
+
+
+ 
  
 ## JKS Options  
 Just as Jetty requires a JKS to enable https, the SAML2 SP bundle requires a JKS to hold the IDP's signing certificate and to hold the SAML2 Service providers encryption key-pair. One suggestion is to locate these under the sling folder...

--- a/saml-handler/bundle-configuration.bnd
+++ b/saml-handler/bundle-configuration.bnd
@@ -7,7 +7,7 @@ Bundle-Activator: org.apache.sling.auth.saml2.Activator
 
 Import-Package:!com.beust*,!antlr*,!org.apache.log.*,!org.apache.oro.text.perl*,!com.google.apphosting*,\
 !org.apache.tools.ant.*,!org.jdom*,!com.sun.org.apache.xerces.internal*,!sun.io,!org.bouncycastle.*,\
-!junit.framework*,!org.dom4j.*,!com.sun.msv.*,!sun.misc,javax.annotation;version=0.0.0,*
+!junit.framework*,!org.dom4j.*,!com.sun.msv.*,!sun.misc,javax.annotation;version=0.0.0,!org.relaxng.datatype.*,*
 
 -removeheaders: Include-Resource, Private-Package
 
@@ -40,7 +40,6 @@ xom-[0-9\.]+.jar;lib:=true,\
 jaxen-[0-9\.]+.jar;lib:=true,\
 error_prone_annotations-[0-9\.]+.jar;lib:=true,\
 xml-apis-[0-9\.]+.jar;lib:=true,\
-com.springsource.org.relaxng.datatype-[0-9\.]+.jar;lib:=true,\
 woodstox-core-[0-9\.]+.jar;lib:=true,\
 stax2-api-[0-9\.]+.jar;lib:=true,\
 

--- a/saml-handler/pom.xml
+++ b/saml-handler/pom.xml
@@ -121,11 +121,6 @@
     </dependency>
 
 <!-- OpenSAML Dependencies-->
-    <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk15on</artifactId>
-      <version>1.59</version>
-    </dependency>
 
     <dependency>
       <groupId>org.apache.xml.security</groupId>
@@ -186,18 +181,6 @@
       <artifactId>joda-convert</artifactId>
       <version>1.9.2</version>
     </dependency>
-
-    <dependency>
-      <groupId>org.relaxng</groupId>
-      <artifactId>com.springsource.org.relaxng.datatype</artifactId>
-      <version>1.0.0</version>
-    </dependency>
-
-<!--    <dependency>-->
-<!--      <groupId>org.codehaus.woodstox</groupId>-->
-<!--      <artifactId>stax2-api</artifactId>-->
-<!--      <version>3.1.4</version>-->
-<!--    </dependency>-->
 
 
     <!--    JavaEE -->


### PR DESCRIPTION
removed optional transitive Spring's org.relaxng.datatype from dom4j, which itself is not needed