### PR TITLE
SLING-9526 - Allow launching feature model applications in external processes, non-blocking

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
           <module>starter-system-info</module>
           <module>metrics-prometheus</module>
           <module>saml-handler</module>
+          <module>feature-launcher-maven-plugin</module>
     </modules>
 
 </project>


### PR DESCRIPTION
Include the feature-launcher-maven-plugin in the reactor