### PR TITLE
SLING-9526 - Allow launching feature model applications in external processes, non-blocking

### DIFF
--- a/feature-launcher-maven-plugin/pom.xml
+++ b/feature-launcher-maven-plugin/pom.xml
@@ -39,7 +39,7 @@
     </prerequisites>
 
     <properties>
-        <sling.java.version>11</sling.java.version>
+        <sling.java.version>8</sling.java.version>
         <maven.version>3.3.9</maven.version>
     </properties>
 

--- a/feature-launcher-maven-plugin/src/main/java/org/apache/sling/maven/feature/launcher/StartMojo.java
+++ b/feature-launcher-maven-plugin/src/main/java/org/apache/sling/maven/feature/launcher/StartMojo.java
@@ -26,6 +26,7 @@ import java.io.InputStreamReader;
 import java.lang.ProcessBuilder.Redirect;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -122,7 +123,7 @@ public class StartMojo
                 args.add("-p");
                 args.add(launch.getId()); // TODO - validate launch id is a valid file name
                 
-                for ( var frameworkProperty : launch.getLauncherArguments().getFrameworkProperties().entrySet() ) {
+                for ( Map.Entry<String, String> frameworkProperty : launch.getLauncherArguments().getFrameworkProperties().entrySet() ) {
                     args.add("-D");
                     args.add(frameworkProperty.getKey()+"="+frameworkProperty.getValue());
                 }


### PR DESCRIPTION
Switch to Java 8 as we still need to run the Sling ITs with that version.